### PR TITLE
Fixed parameter parsing for string annotations.

### DIFF
--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -1,6 +1,6 @@
 import inspect
 from collections import OrderedDict
-from typing import Any, Callable, Coroutine, Optional, TypeVar
+from typing import Any, Callable, Coroutine, Optional, TypeVar, get_type_hints
 
 from taskiq.abc.broker import AsyncBroker
 from taskiq.abc.result_backend import AsyncResultBackend, TaskiqResult
@@ -126,6 +126,10 @@ class InMemoryBroker(AsyncBroker):
             raise TaskiqError("Unknown task.")
         if not self.receiver.task_signatures.get(target_task.task_name):
             self.receiver.task_signatures[target_task.task_name] = inspect.signature(
+                target_task.original_func,
+            )
+        if not self.receiver.task_hints.get(target_task.task_name):
+            self.receiver.task_hints[target_task.task_name] = get_type_hints(
                 target_task.original_func,
             )
 

--- a/taskiq/cli/tests/test_context.py
+++ b/taskiq/cli/tests/test_context.py
@@ -1,4 +1,4 @@
-import inspect
+from typing import get_type_hints
 
 from taskiq.cli.receiver import inject_context
 from taskiq.context import Context
@@ -20,7 +20,36 @@ def test_inject_context_success() -> None:
     )
 
     inject_context(
-        inspect.signature(func),
+        get_type_hints(func),
+        message=message,
+        broker=None,  # type: ignore
+    )
+
+    assert message.kwargs.get("ctx")
+    assert isinstance(message.kwargs["ctx"], Context)
+
+
+def test_inject_context_success_string_annotation() -> None:
+    """
+    Test that context variable is injected as expected.
+
+    This test checks that if Context was provided as
+    string, then everything is work as expected.
+    """
+
+    def func(param1: int, ctx: "Context") -> int:
+        return param1
+
+    message = TaskiqMessage(
+        task_id="",
+        task_name="",
+        labels={},
+        args=[1],
+        kwargs={},
+    )
+
+    inject_context(
+        get_type_hints(func),
         message=message,
         broker=None,  # type: ignore
     )
@@ -44,7 +73,7 @@ def test_inject_context_no_typehint() -> None:
     )
 
     inject_context(
-        inspect.signature(func),
+        get_type_hints(func),
         message=message,
         broker=None,  # type: ignore
     )
@@ -71,7 +100,7 @@ def test_inject_context_no_ctx_parameter() -> None:
     )
 
     inject_context(
-        inspect.signature(func),
+        get_type_hints(func),
         message=message,
         broker=None,  # type: ignore
     )

--- a/taskiq/cli/tests/test_parameters_parsing.py
+++ b/taskiq/cli/tests/test_parameters_parsing.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass
-from typing import Any, Type
+from typing import Any, Type, get_type_hints
 
 import pytest
 from pydantic import BaseModel
@@ -30,6 +30,7 @@ def test_parse_params_no_signature() -> None:
     modify_msg = src_msg.copy(deep=True)
     parse_params(
         signature=None,
+        type_hints={},
         message=modify_msg,
     )
 
@@ -51,7 +52,11 @@ def test_parse_params_classes(test_class: Type[Any]) -> None:
         kwargs={},
     )
 
-    parse_params(inspect.signature(test_func), msg_with_args)
+    parse_params(
+        inspect.signature(test_func),
+        get_type_hints(test_func),
+        msg_with_args,
+    )
 
     assert isinstance(msg_with_args.args[0], test_class)
     assert msg_with_args.args[0].field == "test_val"
@@ -64,7 +69,11 @@ def test_parse_params_classes(test_class: Type[Any]) -> None:
         kwargs={"param": {"field": "test_val"}},
     )
 
-    parse_params(inspect.signature(test_func), msg_with_kwargs)
+    parse_params(
+        inspect.signature(test_func),
+        get_type_hints(test_func),
+        msg_with_kwargs,
+    )
 
     assert isinstance(msg_with_kwargs.kwargs["param"], test_class)
     assert msg_with_kwargs.kwargs["param"].field == "test_val"
@@ -85,7 +94,11 @@ def test_parse_params_wrong_data(test_class: Type[Any]) -> None:
         kwargs={},
     )
 
-    parse_params(inspect.signature(test_func), msg_with_args)
+    parse_params(
+        inspect.signature(test_func),
+        get_type_hints(test_func),
+        msg_with_args,
+    )
 
     assert isinstance(msg_with_args.args[0], dict)
 
@@ -97,7 +110,11 @@ def test_parse_params_wrong_data(test_class: Type[Any]) -> None:
         kwargs={"param": {"unknown": "unknown"}},
     )
 
-    parse_params(inspect.signature(test_func), msg_with_kwargs)
+    parse_params(
+        inspect.signature(test_func),
+        get_type_hints(test_func),
+        msg_with_kwargs,
+    )
 
     assert isinstance(msg_with_kwargs.kwargs["param"], dict)
 
@@ -117,7 +134,7 @@ def test_parse_params_nones(test_class: Type[Any]) -> None:
         kwargs={},
     )
 
-    parse_params(inspect.signature(test_func), msg_with_args)
+    parse_params(inspect.signature(test_func), get_type_hints(test_func), msg_with_args)
 
     assert msg_with_args.args[0] is None
 
@@ -129,6 +146,10 @@ def test_parse_params_nones(test_class: Type[Any]) -> None:
         kwargs={"param": None},
     )
 
-    parse_params(inspect.signature(test_func), msg_with_kwargs)
+    parse_params(
+        inspect.signature(test_func),
+        get_type_hints(test_func),
+        msg_with_kwargs,
+    )
 
     assert msg_with_kwargs.kwargs["param"] is None


### PR DESCRIPTION
This request fixes type resolving for python3.11+. Since in modern versions of python
all types are converted to strings. 

You can enable this by importing 
```
from __future__ import annotations
```

This request fixed logic how types are resolved.

Signed-off-by: Pavel Kirilin <win10@list.ru>