### PR TITLE
Added comparison table in docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Pavel Kirilin
+Copyright (c) 2022-2023 Pavel Kirilin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ head:
     - name: "google-site-verification"
       content: "hQCR5w2tmeuOvYIYXsOYU3u4kLNwT86lnqltANYlRQ0"
 features:
+    - title: Production ready
+      details: Taskiq has proven that it can run in heavy-production systems with high load.
     - title: Fully asynchronous
       details: Taskiq can run both sync and async functions. You don't have to worry about it.
     - title: Easily extensible
@@ -23,9 +25,7 @@ features:
         your own broker or middleware.
     - title: Strongly typed
       details: Taskiq provides correct autocompletion for most of its functionality.
-    - title: Simple
-      details: We tried to make the interface to be as simple as possible. And we are proud of it.
-footer: MIT Licensed | Copyright© 2022
+footer: MIT Licensed | Copyright© 2022-2023
 ---
 
 ## Installation

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ head:
       content: "hQCR5w2tmeuOvYIYXsOYU3u4kLNwT86lnqltANYlRQ0"
 features:
     - title: Production ready
-      details: Taskiq has proven that it can run in heavy-production systems with high load.
+      details: Taskiq has proven that it can run in heavy production systems with high load.
     - title: Fully asynchronous
       details: Taskiq can run both sync and async functions. You don't have to worry about it.
     - title: Easily extensible

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -27,7 +27,7 @@ You might have seen projects built on top of asyncio that solve similar problem,
 |         Actively maintained |   ✅    |   ✅   |    ❌     |
 |    Multiple broker backends |   ✅    |   ❌   |    ✅     |
 |    Multiple result backends |   ✅    |   ❌   |    ❌     |
-|  Have  a rich documentation |   ✅    |   ❌   |    ❌     |
+|  Have a rich documentation  |   ✅    |   ❌   |    ❌     |
 |   Startup & Shutdown events |   ✅    |   ✅   |    ❌     |
 | Have ability to abort tasks |   ❌    |   ✅   |    ❌     |
 |          Custom serializers |   ✅    |   ✅   |    ❌     |

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -18,8 +18,22 @@ replaceable parts, such as brokers, result backends, and middlewares.
 ## Why not use existing libraries?
 
 We couldn't find a solution like Celery or Dramatiq that can run async code and send tasks asynchronously.
-It was the main reason we created this project. It's still in the early stages of development,
-so it's not a production-ready solution yet. We use it at work, but still, you may encounter bugs.
-If your project requires mature solutions, please use Dramatiq or Celery instead.
+It was the main reason we created this project.
 
-Also, this project is not for you if you have a fully synchronous project.
+You might have seen projects built on top of asyncio that solve similar problem, but here's a comparasion table of taskiq and other projects.
+
+|                Feature name | Taskiq |  Arq  | AioTasks |
+| --------------------------: | :----: | :---: | :------: |
+|         Actively maintained |   ✅    |   ✅   |    ❌     |
+|    Multiple broker backends |   ✅    |   ❌   |    ✅     |
+|    Multiple result backends |   ✅    |   ❌   |    ❌     |
+|  Have  a rich documentation |   ✅    |   ❌   |    ❌     |
+|   Startup & Shutdown events |   ✅    |   ✅   |    ❌     |
+| Have ability to abort tasks |   ❌    |   ✅   |    ❌     |
+|          Custom serializers |   ✅    |   ✅   |    ❌     |
+|        Dependency injection |   ✅    |   ❌   |    ❌     |
+|              Task pipelines |   ✅    |   ✅   |    ❌     |
+|              Task schedules |   ✅    |   ✅   |    ❌     |
+|          Global middlewares |   ✅    |   ❌   |    ❌     |
+
+If you have a fully synchronous project, consider using celery or dramatiq instead.


### PR DESCRIPTION
This request updates documentation. It adds info about current state of taskiq development and a comparison table for taskiq and other async task managers.