### PR TITLE
Added ability to add custom first-level dependencies

### DIFF
--- a/docs/guide/state-and-deps.md
+++ b/docs/guide/state-and-deps.md
@@ -171,3 +171,13 @@ By default taskiq has only two deendencies:
 
 - Context from `taskiq.context.Context`
 - TaskiqState from `taskiq.state.TaskiqState`
+
+
+### Adding first-level dependencies
+
+You can expand default list of available dependencies for you application.
+Taskiq have an ability to add new first-level dependencies using brokers.
+
+The AsyncBroker interface has a function called `add_dependency_context` and you can add
+more default dependencies to the taskiq. This may be useful for libraries if you want to
+add new dependencies to users.

--- a/taskiq/abc/broker.py
+++ b/taskiq/abc/broker.py
@@ -86,11 +86,23 @@ class AsyncBroker(ABC):  # noqa: WPS230
         # Every event has a list of handlers.
         # Every handler is a function which takes state as a first argument.
         # And handler can be either sync or async.
-        self.event_handlers: DefaultDict[  # noqa: WPS234
+        self.event_handlers: DefaultDict[
             TaskiqEvents,
             List[Callable[[TaskiqState], Optional[Awaitable[None]]]],
         ] = defaultdict(list)
         self.state = TaskiqState()
+        self.custom_dependency_context: Dict[Any, Any] = {}
+
+    def add_dependency_context(self, new_ctx: Dict[Any, Any]) -> None:
+        """
+        Add first-level dependencies.
+
+        Provided dict will be used to inject new dependencies
+        in all dependency graph contexts.
+
+        :param new_ctx: Additional context values for dependnecy injection.
+        """
+        self.custom_dependency_context.update(new_ctx)
 
     def add_middlewares(self, *middlewares: "TaskiqMiddleware") -> None:
         """

--- a/taskiq/cli/worker/receiver.py
+++ b/taskiq/cli/worker/receiver.py
@@ -159,12 +159,14 @@ class Receiver:
         dep_ctx = None
         if dependency_graph:
             # Create a context for dependency resolving.
-            dep_ctx = dependency_graph.async_ctx(
+            broker_ctx = self.broker.custom_dependency_context
+            broker_ctx.update(
                 {
                     Context: Context(message, self.broker),
                     TaskiqState: self.broker.state,
                 },
             )
+            dep_ctx = dependency_graph.async_ctx(broker_ctx)
             # Resolve all function's dependencies.
             dep_kwargs = await dep_ctx.resolve_kwargs()
             for key, val in dep_kwargs.items():


### PR DESCRIPTION
This feature allow lib developers to add new first-level dependencies for users. This will be used by `taskiq-fastapi` project.