### PR TITLE
Replaced string with bytes in BrokerMessage

### DIFF
--- a/taskiq/formatters/json_formatter.py
+++ b/taskiq/formatters/json_formatter.py
@@ -15,7 +15,7 @@ class JSONFormatter(TaskiqFormatter):
         return BrokerMessage(
             task_id=message.task_id,
             task_name=message.task_name,
-            message=message.json(),
+            message=message.json().encode(),
             labels=message.labels,
         )
 

--- a/taskiq/message.py
+++ b/taskiq/message.py
@@ -24,5 +24,5 @@ class BrokerMessage(BaseModel):
 
     task_id: str
     task_name: str
-    message: str
+    message: bytes
     labels: Dict[str, str]


### PR DESCRIPTION
bytes are more reliable than string. It would be easier to transfer objects which are not compatible with utf-8 using bytes.