### PR TITLE
Reload dependencies are now optional.

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -47,10 +47,29 @@ To disable this pass the `--no-parse` option to the taskiq.
 ### Hot reload
 
 This is annoying to restart workers every time you modify tasks. That's why taskiq supports hot-reload.
-To enable this option simply pass the `--reload` or `-r` option to taskiq CLI.
+Reload is unavailable by default. To enable this feature install taskiq with `reload` extra.
 
-Also this option supports `.gitignore` files. If you have such files in your directory. It won't reload worker
-if you ignore file's contents. To disable this functionality pass `--do-not-use-gitignore` option.
+::: tabs
+
+
+@tab pip
+
+```bash:no-line-numbers
+pip install "taskiq[reload]"
+```
+
+@tab poetry
+
+```bash:no-line-numbers
+poetry add taskiq -E reload
+```
+
+:::
+
+To enable this option simply pass the `--reload` or `-r` option to worker taskiq CLI.
+
+Also this option supports `.gitignore` files. If you have such file in your directory, it won't reload worker
+when you modify ignored files. To disable this functionality pass `--do-not-use-gitignore` option.
 
 ## Scheduler
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -658,7 +658,7 @@ name = "gitignore-parser"
 version = "0.1.3"
 description = "A spec-compliant gitignore parser for Python 3.5+"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "gitignore_parser-0.1.3.tar.gz", hash = "sha256:d0150d81889251d00cde6cf38931ab5613ca1109f5b3905a232c8458ff0d6991"},
@@ -1207,18 +1207,17 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
+    {file = "pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
@@ -1228,7 +1227,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -1698,7 +1697,7 @@ name = "watchdog"
 version = "2.3.1"
 description = "Filesystem events monitoring"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "watchdog-2.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1f1200d4ec53b88bf04ab636f9133cb703eb19768a39351cee649de21a33697"},
@@ -1802,10 +1801,11 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [extras]
 metrics = ["prometheus_client"]
+reload = ["gitignore-parser", "watchdog"]
 uv = ["uvloop"]
 zmq = ["pyzmq"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "ef91f1450bb3c234cc7fc1cda2b36c9cd45e36c05b3f4ff95596471b0803cbe9"
+content-hash = "c01c1d6fa835856f80ff658987258fbb0af7fcae092c97f2faf78b684be0fe40"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,18 @@ keywords = ["taskiq", "tasks", "distributed", "async"]
 python = "^3.7"
 typing-extensions = ">=3.10.0.0"
 pydantic = "^1.6.2"
-pyzmq = { version = "^23.2.0", optional = true }
-uvloop = { version = ">=0.16.0,<1", optional = true }
-watchdog = "^2.1.9"
-gitignore-parser = "^0"
 importlib-metadata = "*"
 pycron = "^3.0.0"
 taskiq_dependencies = "^1"
+# For prometheus metrics
 prometheus_client = { version = "^0", optional = true }
+# For ZMQBroker
+pyzmq = { version = "^23.2.0", optional = true }
+# For speed
+uvloop = { version = ">=0.16.0,<1", optional = true }
+# For hot-reload.
+watchdog = { version = "^2.1.9", optional = true }
+gitignore-parser = { version = "^0", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
@@ -59,6 +63,7 @@ types-mock = "^4.0.15"
 zmq = ["pyzmq"]
 uv = ["uvloop"]
 metrics = ["prometheus_client"]
+reload = ["watchdog", "gitignore-parser"]
 
 [tool.poetry.scripts]
 taskiq = "taskiq.__main__:main"

--- a/taskiq/__main__.py
+++ b/taskiq/__main__.py
@@ -46,8 +46,8 @@ def main() -> None:  # noqa: WPS210  # pragma: no cover
     for entrypoint in entry_points().select(group="taskiq_cli"):
         try:
             cmd_class = entrypoint.load()
-        except ImportError:
-            print(f"Could not load {entrypoint.value}")  # noqa: WPS421
+        except ImportError as exc:
+            print(f"Could not load {entrypoint.value}. Cause: {exc}")  # noqa: WPS421
             continue
         if issubclass(cmd_class, TaskiqCMD):
             subparsers.add_parser(

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -116,7 +116,8 @@ class WorkerArgs:
             "--reload",
             "-r",
             action="store_true",
-            help="Reload workers if file is changed.",
+            help="Reload workers if file is changed. "
+            + "`reload` extra is required for this option.",
         )
         parser.add_argument(
             "--do-not-use-gitignore",


### PR DESCRIPTION
This PR makes watchdog and gitignore parser dependencies optional. Now if you install taskiq it won't install reload packages by default. It makes it smaller for production use. Because these dependencies are only required for development.