### PR TITLE
fix: execution time retains 2 digits

### DIFF
--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -214,7 +214,7 @@ class Receiver:
             is_err=found_exception is not None,
             log=None,
             return_value=returned,
-            execution_time=execution_time,
+            execution_time=round(execution_time, 2),
         )
         # If exception is found we execute middlewares.
         if found_exception is not None:


### PR DESCRIPTION
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/43594924/236378197-97a8a633-4a42-48e4-8974-3ee84d522728.png">

When using the memory broker, because the task is executed quickly, the execution time becomes scientific notation, so I think it is enough to keep 2 decimal places