### PR TITLE
fix: kiq and kicker type hint

### DIFF
--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -72,7 +72,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
         *args: _FuncParams.args,
         **kwargs: _FuncParams.kwargs,
-    ) -> AsyncTaskiqTask[_ReturnType]:
+    ) -> AsyncTaskiqTask[Any]:
         ...
 
     async def kiq(
@@ -93,7 +93,17 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         """
         return await self.kicker().kiq(*args, **kwargs)
 
-    def kicker(self) -> AsyncKicker[_FuncParams, _ReturnType]:
+    @overload
+    def kicker(self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]"
+               ) -> AsyncKicker[_FuncParams, _T]:
+        ...
+
+    @overload
+    def kicker(self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
+               ) -> AsyncKicker[Any, Any]:
+        ...
+
+    def kicker(self) -> Any:
         """
         This function returns kicker object.
 

--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -1,13 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    Dict,
-    Generic,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -59,27 +50,11 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
     ) -> _ReturnType:
         return self.original_func(*args, **kwargs)
 
-    @overload
-    async def kiq(
-        self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]",
-        *args: _FuncParams.args,
-        **kwargs: _FuncParams.kwargs,
-    ) -> AsyncTaskiqTask[_T]:
-        ...
-
-    @overload
-    async def kiq(
-        self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
-        *args: _FuncParams.args,
-        **kwargs: _FuncParams.kwargs,
-    ) -> AsyncTaskiqTask[Any]:
-        ...
-
     async def kiq(
         self,
         *args: _FuncParams.args,
         **kwargs: _FuncParams.kwargs,
-    ) -> Any:
+    ) -> AsyncTaskiqTask[Any]:
         """
         This method sends function call over the network.
 
@@ -93,19 +68,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         """
         return await self.kicker().kiq(*args, **kwargs)
 
-    @overload
-    def kicker(
-        self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]",
-    ) -> AsyncKicker[_FuncParams, _T]:
-        ...
-
-    @overload
-    def kicker(
-        self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
-    ) -> AsyncKicker[Any, Any]:
-        ...
-
-    def kicker(self) -> Any:
+    def kicker(self) -> AsyncKicker[Any, Any]:
         """
         This function returns kicker object.
 

--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -94,13 +94,15 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         return await self.kicker().kiq(*args, **kwargs)
 
     @overload
-    def kicker(self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]"
-               ) -> AsyncKicker[_FuncParams, _T]:
+    def kicker(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]",
+    ) -> AsyncKicker[_FuncParams, _T]:
         ...
 
     @overload
-    def kicker(self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
-               ) -> AsyncKicker[Any, Any]:
+    def kicker(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
+    ) -> AsyncKicker[Any, Any]:
         ...
 
     def kicker(self) -> Any:

--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -1,4 +1,13 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Generic,
+    TypeVar,
+    overload,
+)
 
 from typing_extensions import ParamSpec
 
@@ -50,11 +59,36 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
     ) -> _ReturnType:
         return self.original_func(*args, **kwargs)
 
+    @overload
+    async def kiq(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]",
+        *args: _FuncParams.args,
+        **kwargs: _FuncParams.kwargs,
+    ) -> AsyncTaskiqTask[_T]:
+        ...
+
+    @overload
+    async def kiq(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
+        *args: _FuncParams.args,
+        **kwargs: _FuncParams.kwargs,
+    ) -> AsyncTaskiqTask[_ReturnType]:
+        ...
+
+    # This is a patch to pycharm type hints todo
+    @overload
+    async def kiq(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, Any]",
+        *args: _FuncParams.args,
+        **kwargs: _FuncParams.kwargs,
+    ) -> AsyncTaskiqTask[Any]:
+        ...
+
     async def kiq(
         self,
         *args: _FuncParams.args,
         **kwargs: _FuncParams.kwargs,
-    ) -> AsyncTaskiqTask[Any]:
+    ) -> Any:
         """
         This method sends function call over the network.
 
@@ -68,7 +102,26 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         """
         return await self.kicker().kiq(*args, **kwargs)
 
-    def kicker(self) -> AsyncKicker[Any, Any]:
+    @overload
+    def kicker(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, Coroutine[Any, Any, _T]]",
+    ) -> AsyncKicker[_FuncParams, _T]:
+        ...
+
+    @overload
+    def kicker(
+        self: "AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType]",
+    ) -> AsyncKicker[_FuncParams, _ReturnType]:
+        ...
+
+    # This is a patch to pycharm type hints  todo
+    @overload
+    def kicker(
+        self: "AsyncTaskiqDecoratedTask[Any, Any]",
+    ) -> AsyncKicker[Any, Any]:
+        ...
+
+    def kicker(self) -> Any:
         """
         This function returns kicker object.
 


### PR DESCRIPTION
This pr fixes the problem that kiq and kicker do not have type hints in pycharm.

<img width="799" alt="image" src="https://user-images.githubusercontent.com/43594924/236637996-b62c1ce6-f0dd-411e-82cd-a492b454520d.png">
<img width="918" alt="image" src="https://user-images.githubusercontent.com/43594924/236638011-caa81bd9-feae-45a2-8c8c-6d7dc94194f7.png">

