### PR TITLE
Fix typos and command in docs

### DIFF
--- a/docs/available-components/brokers.md
+++ b/docs/available-components/brokers.md
@@ -10,7 +10,7 @@ In this section we'll list officially supported brokers.
 
 This is a special broker for local development. It uses the same functions to execute tasks,
 but all tasks are executed locally in the current thread.
-By default it uses `InMemoryResultBackend` but this can be overriden.
+By default it uses `InMemoryResultBackend` but this can be overridden.
 
 ## ZeroMQBroker
 

--- a/docs/examples/extending/result_backend.py
+++ b/docs/examples/extending/result_backend.py
@@ -53,7 +53,7 @@ class MyResultBackend(AsyncResultBackend[_ReturnType]):
         Check if result exists.
 
         This function must check whether result
-        is available in your resul backend
+        is available in your result backend
         without fetching the result.
 
         :param task_id: id of a task.

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -119,13 +119,13 @@ test_project
 You can specify all tasks modules to import manually.
 
 ```bash
-taskiq test_project.broker:broker test_projec.submodule.tasks test_projec.utils.tasks
+taskiq worker test_project.broker:broker test_project.submodule.tasks test_project.utils.tasks
 ```
 
 Or you can let taskiq find all python modules named tasks in current directory recursively.
 
 ```bash
-taskiq test_project.broker:broker -fsd
+taskiq worker test_project.broker:broker -fsd
 ```
 
 If you have uvloop installed, taskiq will automatically install new policies to event loop.

--- a/docs/guide/scheduling-tasks.md
+++ b/docs/guide/scheduling-tasks.md
@@ -22,7 +22,7 @@ Of course we can implement loop like this:
         await asyncio.sleep(timedelta(minutes=5).total_seconds)
 ```
 
-But if you have many schedules it may be a little painful to implement. So let me introuce you the `TaskiqScheduler`.
+But if you have many schedules it may be a little painful to implement. So let me introduce you the `TaskiqScheduler`.
 Let's add scheduler to our module.
 
 @[code python](../examples/schedule/intro.py)

--- a/docs/guide/state-and-deps.md
+++ b/docs/guide/state-and-deps.md
@@ -102,7 +102,7 @@ For example:
 
 @[code python](../examples/state/dependencies_tree.py)
 
-In this code, the dependency `common_dep` is going to be evaluated only once and the `dep1` and the `dep2` are going to recevie the same value. You can control this behavior by using the `use_cache=False` parameter to you dependency. This parameter will force the
+In this code, the dependency `common_dep` is going to be evaluated only once and the `dep1` and the `dep2` are going to receive the same value. You can control this behavior by using the `use_cache=False` parameter to you dependency. This parameter will force the
 dependency to reevaluate all it's subdependencies.
 
 In this example we cannot predict the result. Since the `dep2` doesn't use cache for the `common_dep` function.
@@ -167,7 +167,7 @@ If you want to do something asynchronously, convert this function to an asynchro
 
 ### Default dependencies
 
-By default taskiq has only two deendencies:
+By default taskiq has only two dependencies:
 
 - Context from `taskiq.context.Context`
 - TaskiqState from `taskiq.state.TaskiqState`

--- a/docs/guide/taskiq-with-fastapi.md
+++ b/docs/guide/taskiq-with-fastapi.md
@@ -8,7 +8,7 @@ FastAPI is one of the most popular async web frameworks in python. It has gained
 1. It's easy to use;
 2. It has a cool dependency injection.
 
-In taskiq we try to make our libraries easy to use and we too have a depenndency injection. But our dependencies
+In taskiq we try to make our libraries easy to use and we too have a dependency injection. But our dependencies
 are not compatible with FastAPI's dependencies by default. That is why we have created a library "[taskiq-fastapi](https://pypi.org/project/taskiq-fastapi/)" to make integration with
 FastAPI as smooth as possible.
 

--- a/docs/guide/testing-taskiq.md
+++ b/docs/guide/testing-taskiq.md
@@ -4,7 +4,7 @@ order: 9
 
 # Testing with taskiq
 
-Everytime we write programs, we want them to be correct. To achieve this, we use tests.
+Every time we write programs, we want them to be correct. To achieve this, we use tests.
 Taskiq allows you to write tests easily as if tasks were normal functions.
 
 Let's dive into examples.
@@ -76,7 +76,7 @@ After the preparations are done, we need to modify the broker's file in your pro
 
 As you can see, we added an `if` statement. If the expression is true, we replace our broker with an imemory broker.
 The main point here is to not have an actual connection during testing. It's useful because inmemory broker has
-the same interface as a real broker, but it doesn't send tasks acutally.
+the same interface as a real broker, but it doesn't send tasks actually.
 
 ## Testing tasks
 

--- a/taskiq/abc/broker.py
+++ b/taskiq/abc/broker.py
@@ -113,7 +113,7 @@ class AsyncBroker(ABC):
         Provided dict will be used to inject new dependencies
         in all dependency graph contexts.
 
-        :param new_ctx: Additional context values for dependnecy injection.
+        :param new_ctx: Additional context values for dependency injection.
         """
         self.custom_dependency_context.update(new_ctx)
 
@@ -152,7 +152,7 @@ class AsyncBroker(ABC):
         Close the broker.
 
         This method is called,
-        when broker is closig.
+        when broker is closing.
         """
         event = TaskiqEvents.CLIENT_SHUTDOWN
         if self.is_worker_process:

--- a/taskiq/abc/middleware.py
+++ b/taskiq/abc/middleware.py
@@ -55,7 +55,7 @@ class TaskiqMiddleware:  # pragma: no cover
         """
         This hook is called before executing task.
 
-        This is a worker-side hook, wich means it
+        This is a worker-side hook, which means it
         executes in the worker process.
 
         :param message: incoming parsed taskiq message.

--- a/taskiq/abc/result_backend.py
+++ b/taskiq/abc/result_backend.py
@@ -20,7 +20,7 @@ class AsyncResultBackend(ABC, Generic[_ReturnType]):
         """
         Saves result to the result backend.
 
-        Result must be save so it can be accesed later
+        Result must be save so it can be accessed later
         by the calling side of the system.
 
         :param task_id: id of a task to save.

--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -114,7 +114,7 @@ class InMemoryBroker(AsyncBroker):
 
         This method just executes given task.
 
-        :param message: incomming message.
+        :param message: incoming message.
 
         :raises TaskiqError: if someone wants to kick unknown task.
         """

--- a/taskiq/cli/scheduler/args.py
+++ b/taskiq/cli/scheduler/args.py
@@ -42,7 +42,7 @@ class SchedulerArgs:
             help=(
                 "If this option is on, "
                 "taskiq will try to find tasks modules "
-                "in current directory recursievly. Name of file to search for "
+                "in current directory recursively. Name of file to search for "
                 "can be configured using `--tasks-pattern` option."
             ),
         )

--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -20,7 +20,7 @@ async def schedules_updater(
     """
     Periodic update to schedules.
 
-    This task preiodicaly checks for new schedules,
+    This task periodically checks for new schedules,
     assembles the final list and replaces current
     schedule with a new one.
 

--- a/taskiq/cli/watcher.py
+++ b/taskiq/cli/watcher.py
@@ -9,7 +9,7 @@ logger = getLogger("taskiq.worker")
 
 
 class FileWatcher:  # pragma: no cover
-    """Filewatcher that watchs for filesystem changes."""
+    """Filewatcher that watches for filesystem changes."""
 
     def __init__(
         self,

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -100,7 +100,7 @@ class WorkerArgs:
             help=(
                 "If this option is on, "
                 "taskiq will try to find tasks modules "
-                "in current directory recursievly. Name of file to search for "
+                "in current directory recursively. Name of file to search for "
                 "can be configured using `--tasks-pattern` option."
             ),
         )
@@ -127,7 +127,7 @@ class WorkerArgs:
                 "[%(module)s:%(funcName)s:%(lineno)d] "
                 "%(message)s"
             ),
-            help="Format wich is used when collecting logs from function execution",
+            help="Format which is used when collecting logs from function execution",
         )
         parser.add_argument(
             "--no-parse",

--- a/taskiq/cli/worker/log_collector.py
+++ b/taskiq/cli/worker/log_collector.py
@@ -12,7 +12,7 @@ class Redirector:
 
     def write(self, message: Any) -> None:
         """
-        This write request writes to all avaialble streams.
+        This write request writes to all available streams.
 
         :param message: message to write.
         """

--- a/taskiq/cli/worker/process_manager.py
+++ b/taskiq/cli/worker/process_manager.py
@@ -108,7 +108,7 @@ def get_signal_handler(
     action_queue: "Queue[ProcessActionBase]",
 ) -> Callable[[int, Any], None]:
     """
-    Generate singnal handler for main process.
+    Generate signal handler for main process.
 
     The signal handler will just put the SHUTDOWN event in
     the action queue.

--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -28,13 +28,13 @@ async def shutdown_broker(broker: AsyncBroker, timeout: float) -> None:
     """
     This function used to shutdown broker.
 
-    Broker can throw erorrs during shutdown,
+    Broker can throw errors during shutdown,
     or it may return some value.
 
     We need to handle such situations.
 
     :param broker: current broker.
-    :param timeout: maximum amout of time to shutdown the broker.
+    :param timeout: maximum amount of time to shutdown the broker.
     """
     logger.warning("Shutting down the broker.")
     try:
@@ -70,7 +70,7 @@ def start_listen(args: WorkerArgs) -> None:  # noqa: WPS210, WPS213
     This function starts actual listening process.
 
     It imports broker and all tasks.
-    Since tasks registers themselfs in a global set,
+    Since tasks registers themselves in a global set,
     it's easy to just import module where you have decorated
     function and they will be available in broker's `available_tasks`
     field.
@@ -110,7 +110,7 @@ def start_listen(args: WorkerArgs) -> None:  # noqa: WPS210, WPS213
 
         :param signum: received signal number.
         :param _frame: current execution frame.
-        :raises KeyboardInterrupt: if termiation hasn't begun.
+        :raises KeyboardInterrupt: if termination hasn't begun.
         """
         logger.debug(f"Got signal {signum}.")
         nonlocal shutting_down  # noqa: WPS420
@@ -169,7 +169,7 @@ def run_worker(args: WorkerArgs) -> None:  # noqa: WPS213
         observer.start()
         args.workers = 1
         logging.warning(
-            "Reload on chage enabled. Number of worker processes set to 1.",
+            "Reload on change enabled. Number of worker processes set to 1.",
         )
 
     manager = ProcessManager(args=args, observer=observer, worker_function=start_listen)

--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -50,7 +50,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         self.original_func = original_func
         self.labels = labels
 
-    # Docs for this method are ommited in order to help
+    # Docs for this method are omitted in order to help
     # your IDE resolve correct docs for it.
     def __call__(  # noqa: D102
         self,
@@ -97,8 +97,8 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         """
         This function returns kicker object.
 
-        Kicker is a object that can modyfy kiq request
-        before sendig it.
+        Kicker is a object that can modify kiq request
+        before sending it.
 
         :return: AsyncKicker instance.
         """

--- a/taskiq/events.py
+++ b/taskiq/events.py
@@ -7,7 +7,7 @@ class TaskiqEvents(enum.Enum):
 
     # Worker events.
 
-    # Called on woker startup.
+    # Called on worker startup.
     WORKER_STARTUP = "WORKER_STARTUP"
     # Called o worker shutdown.
     WORKER_SHUTDOWN = "WORKER_SHUTDOWN"

--- a/taskiq/message.py
+++ b/taskiq/message.py
@@ -9,7 +9,7 @@ class TaskiqMessage(BaseModel):
 
     This an internal class used
     by brokers. Every remote call
-    recieve such messages.
+    receive such messages.
     """
 
     task_id: str

--- a/taskiq/receiver/params_parser.py
+++ b/taskiq/receiver/params_parser.py
@@ -32,7 +32,7 @@ def parse_params(  # noqa: C901
     >>> def my_task(a: int) -> str
     >>>     ...
 
-    If you will kall my_task.kiq("11")
+    If you will call my_task.kiq("11")
 
     You'll receive parsed 11 (int).
     But, if you call it with mytask.kiq("str"),

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -78,7 +78,7 @@ class Receiver:
         that came from brokers.
 
         :raises Exception: if raise_err is true,
-            and excpetion were found while saving result.
+            and exception were found while saving result.
         :param message: received message.
         :param raise_err: raise an error if cannot save result in
             result_backend.

--- a/taskiq/schedule_sources/label_based.py
+++ b/taskiq/schedule_sources/label_based.py
@@ -19,7 +19,7 @@ class LabelScheduleSource(ScheduleSource):
         tasks available to the broker.
 
         If task has a schedule label,
-        it will be parsed and retuned.
+        it will be parsed and returned.
 
         :return: list of schedules.
         """

--- a/taskiq/task.py
+++ b/taskiq/task.py
@@ -55,10 +55,10 @@ class _Task(ABC, Generic[_ReturnType]):
         """
         Wait for result to become ready and get it.
 
-        This function constantly checks wheter result is ready
+        This function constantly checks whether result is ready
         and fetches it when it becomes available.
 
-        :param check_interval: how ofen availability is checked.
+        :param check_interval: how often availability is checked.
         :param timeout: maximum amount of time it will wait
             before raising TaskiqResultTimeoutError.
         :param with_logs: whether you need to download logs.
@@ -81,7 +81,7 @@ class AsyncTaskiqTask(_Task[_ReturnType]):
         """
         Checks if task is completed.
 
-        :raises ResultIsReadyError: if we can't get info about task readyness.
+        :raises ResultIsReadyError: if we can't get info about task readiness.
 
         :return: True if task is completed.
         """

--- a/tests/cli/worker/test_receiver.py
+++ b/tests/cli/worker/test_receiver.py
@@ -72,7 +72,7 @@ async def test_run_task_successfull_async() -> None:
 
 
 @pytest.mark.anyio
-async def test_run_task_successfull_sync() -> None:
+async def test_run_task_successful_sync() -> None:
     """Tests that run_task can run sync tasks."""
 
     def test_func(param: int) -> int:
@@ -155,7 +155,7 @@ async def test_run_task_exception_middlewares() -> None:
 
 @pytest.mark.anyio
 async def test_callback_success() -> None:
-    """Test that callback funcion works well."""
+    """Test that callback function works well."""
     broker = InMemoryBroker()
     called_times = 0
 
@@ -252,7 +252,7 @@ async def test_custom_ctx() -> None:
 
 @pytest.mark.anyio
 async def test_callback_semaphore() -> None:
-    """Test that callback funcion semaphore works well."""
+    """Test that callback function semaphore works well."""
     max_async_tasks = 3
     broker = BrokerForTests()
     sem_num = 0

--- a/tests/middlewares/test_simple_retry.py
+++ b/tests/middlewares/test_simple_retry.py
@@ -18,7 +18,7 @@ def broker() -> AsyncMock:
 
 
 @pytest.mark.anyio
-async def test_successfull_retry(broker: AsyncMock) -> None:
+async def test_successful_retry(broker: AsyncMock) -> None:
     middleware = SimpleRetryMiddleware()
     middleware.set_broker(broker)
     await middleware.on_error(

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -10,7 +10,7 @@ from taskiq.task import AsyncTaskiqTask
 
 @pytest.mark.anyio
 async def test_gather() -> None:
-    """Test successfull task gathering."""
+    """Test successful task gathering."""
     rb_mock = AsyncMock()
     rb_mock.is_result_ready.return_value = True
     rb_mock.get_result.return_value = 1


### PR DESCRIPTION
While looking at the docs, I found that the commands 
```
taskiq test_project.broker:broker test_projec.submodule.tasks test_projec.utils.tasks
```
```
taskiq test_project.broker:broker -fsd
```

were missing the `worker` argument.

While fixing it, I also fixed some obvious typos.