### PR TITLE
Added scheduler flag.

### DIFF
--- a/taskiq/abc/broker.py
+++ b/taskiq/abc/broker.py
@@ -68,7 +68,10 @@ class AsyncBroker(ABC):
     """
 
     available_tasks: Dict[str, AsyncTaskiqDecoratedTask[Any, Any]] = {}
+    # True only if broker runs in worker process.
     is_worker_process: bool = False
+    # True only if broker runs in scheduler process.
+    is_scheduler_process: bool = False
 
     def __init__(
         self,

--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -5,6 +5,7 @@ from typing import List
 
 from pycron import is_now
 
+from taskiq.abc.broker import AsyncBroker
 from taskiq.cli.scheduler.args import SchedulerArgs
 from taskiq.cli.utils import import_object, import_tasks
 from taskiq.kicker import AsyncKicker
@@ -70,6 +71,7 @@ async def run_scheduler(args: SchedulerArgs) -> None:  # noqa: C901, WPS210, WPS
 
     :param args: parsed CLI args.
     """
+    AsyncBroker.is_scheduler_process = True
     scheduler = import_object(args.scheduler)
     if not isinstance(scheduler, TaskiqScheduler):
         print(  # noqa: WPS421


### PR DESCRIPTION
This commit adds flag that shows in which environment broker is running
currently.

It's required to fix tasks discovery for projects that use framework
integrations and do not import tasks directly. Closes #142.

Signed-off-by: Pavel Kirilin <win10@list.ru>