### PR TITLE
Register prometheus metrics with multiprocess collector

### DIFF
--- a/taskiq/middlewares/prometheus_middleware.py
+++ b/taskiq/middlewares/prometheus_middleware.py
@@ -83,7 +83,7 @@ class PrometheusMiddleware(TaskiqMiddleware):
         )
         self.execution_time = Histogram(
             "execution_time",
-            "Tome of function execution",
+            "Time of function execution",
             ["task_name"],
             registry=registry,
         )


### PR DESCRIPTION
Registers the prometheus metrics with a CollectorRegistry as specified by the prometheus-client docs: https://github.com/prometheus/client_python/blob/master/README.md#multiprocess-mode-eg-gunicorn

I also notice that the documentation explicitly says to not overwrite `PROMETHEUS_MULTIPROC_DIR` which is being done by the middleware. It seems to be working for me locally, I wonder if it could be a problem?