### PR TITLE
fix: multiprocessing start method on darwin platform

### DIFF
--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 import signal
 from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import set_start_method
 from multiprocessing.synchronize import Event
+from sys import platform
 from typing import Any, Type
 
 from taskiq.abc.broker import AsyncBroker
@@ -158,6 +160,8 @@ def run_worker(args: WorkerArgs) -> None:  # noqa: WPS213
 
     :raises ValueError: if reload flag is used, but dependencies are not installed.
     """
+    if platform == "darwin":
+        set_start_method("fork")
     if args.configure_logging:
         logging.basicConfig(
             level=logging.getLevelName(args.log_level),


### PR DESCRIPTION
Calling `Process.start()` on MacOS or Windows generate this issue:

```
poetry run taskiq worker escalidrawapi.broker:broker
[2023-07-17 17:06:29,035][taskiq.worker][INFO   ][MainProcess] Starting 2 worker processes.
[2023-07-17 17:06:29,040][taskiq.process-manager][INFO   ][MainProcess] Started process worker-0 with pid 23418 
[2023-07-17 17:06:29,042][taskiq.process-manager][INFO   ][MainProcess] Started process worker-1 with pid 23419 
Traceback (most recent call last):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/thoas/.pyenv/versions/3.11.2/lib/python3.11/multiprocessing/spawn.py", line 120, in spawn_main
  File "<string>", line 1, in <module>
  File "/Users/thoas/.pyenv/versions/3.11.2/lib/python3.11/multiprocessing/spawn.py", line 120, in spawn_main
    exitcode = _main(fd, parent_sentinel)
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thoas/.pyenv/versions/3.11.2/lib/python3.11/multiprocessing/spawn.py", line 130, in _main
  File "/Users/thoas/.pyenv/versions/3.11.2/lib/python3.11/multiprocessing/spawn.py", line 130, in _main
    self = reduction.pickle.load(from_parent)
    self = reduction.pickle.load(from_parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thoas/.pyenv/versions/3.11.2/lib/python3.11/multiprocessing/synchronize.py", line 110, in __setstate__
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thoas/.pyenv/versions/3.11.2/lib/python3.11/multiprocessing/synchronize.py", line 110, in __setstate__
    self._semlock = _multiprocessing.SemLock._rebuild(*state)
    self._semlock = _multiprocessing.SemLock._rebuild(*state)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
```

The problem can be resolved by changing the start method, see this [post](https://superfastpython.com/filenotfounderror-multiprocessing-python/).

It's a regression introduced by this [commit](https://github.com/taskiq-python/taskiq/commit/d8699d523783a1df73642fcd127873ea3ec40858).