### PR TITLE
Removed source from the TaskiqSchedule.

### DIFF
--- a/docs/examples/extending/schedule_source.py
+++ b/docs/examples/extending/schedule_source.py
@@ -19,10 +19,6 @@ class MyScheduleSource(ScheduleSource):
                 args=[],
                 kwargs={},
                 cron="* * * * *",
-                #
-                # We need point on self source for calling pre_send / post_send when
-                # task is ready to be enqueued.
-                source=self,
             ),
         ]
 

--- a/taskiq/abc/schedule_source.py
+++ b/taskiq/abc/schedule_source.py
@@ -18,7 +18,7 @@ class ScheduleSource(ABC):
     async def get_schedules(self) -> List["ScheduledTask"]:
         """Get list of taskiq schedules."""
 
-    async def add_schedule(self, schedule: "ScheduledTask") -> None:  # noqa: B027
+    async def add_schedule(self, schedule: "ScheduledTask") -> None:
         """
         Add a new schedule.
 
@@ -33,6 +33,9 @@ class ScheduleSource(ABC):
 
         :param schedule: schedule to add.
         """
+        raise NotImplementedError(
+            f"The source {self.__class__.__name__} does not support adding schedules.",
+        )
 
     def pre_send(  # noqa: B027
         self,

--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -33,7 +33,7 @@ def to_tz_aware(time: datetime) -> datetime:
 
 async def schedules_updater(
     scheduler: TaskiqScheduler,
-    current_schedules: Dict[ScheduleSource, list[ScheduledTask]],
+    current_schedules: Dict[ScheduleSource, List[ScheduledTask]],
     event: asyncio.Event,
 ) -> None:
     """
@@ -49,7 +49,7 @@ async def schedules_updater(
     """
     while True:
         logger.debug("Started schedule update.")
-        new_schedules: "Dict[ScheduleSource, list[ScheduledTask]]" = {}
+        new_schedules: "Dict[ScheduleSource, List[ScheduledTask]]" = {}
         for source in scheduler.sources:
             try:
                 schedules = await source.get_schedules()

--- a/taskiq/schedule_sources/label_based.py
+++ b/taskiq/schedule_sources/label_based.py
@@ -44,7 +44,6 @@ class LabelScheduleSource(ScheduleSource):
                         cron=schedule.get("cron"),
                         time=schedule.get("time"),
                         cron_offset=schedule.get("cron_offset"),
-                        source=self,
                     ),
                 )
         return schedules

--- a/taskiq/scheduler/merge_functions.py
+++ b/taskiq/scheduler/merge_functions.py
@@ -1,3 +1,4 @@
+import copy
 from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -34,8 +35,22 @@ def only_unique(
     :param new_tasks: newly discovered tasks.
     :return: list of unique schedules.
     """
-    result = old_tasks
+    result = copy.copy(old_tasks)
     for task in new_tasks:
         if task not in result:
             result.append(task)
     return result
+
+
+def only_new(
+    _old_tasks: List["ScheduledTask"],
+    new_tasks: List["ScheduledTask"],
+) -> List["ScheduledTask"]:
+    """
+    This function preserves only new schedules.
+
+    :param old_tasks: previously discovered tasks.
+    :param new_tasks: newly discovered schedules.
+    :return: list of new schedules.
+    """
+    return new_tasks

--- a/taskiq/scheduler/scheduler.py
+++ b/taskiq/scheduler/scheduler.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from taskiq.abc.broker import AsyncBroker
 from taskiq.kicker import AsyncKicker
-from taskiq.scheduler.merge_functions import preserve_all
+from taskiq.scheduler.merge_functions import only_new
 from taskiq.utils import maybe_awaitable
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -19,7 +19,6 @@ class ScheduledTask:
     labels: Dict[str, Any]
     args: List[Any]
     kwargs: Dict[str, Any]
-    source: "ScheduleSource"  # Backward point to source which this task belongs to
     cron: Optional[str] = field(default=None)
     cron_offset: Optional[Union[str, timedelta]] = field(default=None)
     time: Optional[datetime] = field(default=None)
@@ -44,7 +43,7 @@ class TaskiqScheduler:
         merge_func: Callable[
             [List["ScheduledTask"], List["ScheduledTask"]],
             List["ScheduledTask"],
-        ] = preserve_all,
+        ] = only_new,
         refresh_delay: float = 30.0,
     ) -> None:  # pragma: no cover
         self.broker = broker
@@ -61,19 +60,19 @@ class TaskiqScheduler:
         """
         await self.broker.startup()
 
-    async def on_ready(self, task: ScheduledTask) -> None:
+    async def on_ready(self, source: "ScheduleSource", task: ScheduledTask) -> None:
         """
         This method is called when task is ready to be enqueued.
 
         It's triggered on proper time depending on `task.cron` or `task.time` attribute.
         :param task: task to send
         """
-        await maybe_awaitable(task.source.pre_send(task))
+        await maybe_awaitable(source.pre_send(task))
         await AsyncKicker(task.task_name, self.broker, task.labels).kiq(
             *task.args,
             **task.kwargs,
         )
-        await maybe_awaitable(task.source.post_send(task))
+        await maybe_awaitable(source.post_send(task))
 
     async def shutdown(self) -> None:
         """Shutdown the scheduler process."""

--- a/tests/cli/scheduler/test_task_delays.py
+++ b/tests/cli/scheduler/test_task_delays.py
@@ -5,10 +5,7 @@ from freezegun import freeze_time
 from tzlocal import get_localzone
 
 from taskiq.cli.scheduler.run import get_task_delay
-from taskiq.schedule_sources.label_based import LabelScheduleSource
 from taskiq.scheduler.scheduler import ScheduledTask
-
-DUMMY_SOURCE = LabelScheduleSource(broker=None)  # type: ignore
 
 
 def test_should_run_success() -> None:
@@ -19,7 +16,6 @@ def test_should_run_success() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             cron=f"* {hour} * * *",
         ),
     )
@@ -35,7 +31,6 @@ def test_should_run_cron_str_offset() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             cron=f"* {hour} * * *",
             cron_offset=str(zone),
         ),
@@ -52,7 +47,6 @@ def test_should_run_cron_td_offset() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             cron=f"* {hour} * * *",
             cron_offset=datetime.timedelta(hours=offset),
         ),
@@ -68,7 +62,6 @@ def test_time_utc_without_zone() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             time=time - datetime.timedelta(seconds=1),
         ),
     )
@@ -83,7 +76,6 @@ def test_time_utc_with_zone() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             time=time - datetime.timedelta(seconds=1),
         ),
     )
@@ -99,7 +91,6 @@ def test_time_utc_with_local_zone() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             time=time - datetime.timedelta(seconds=1),
         ),
     )
@@ -114,7 +105,6 @@ def test_time_localtime_without_zone() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             time=time - datetime.timedelta(seconds=1),
         ),
     )
@@ -130,7 +120,6 @@ def test_time_delay() -> None:
             labels={},
             args=[],
             kwargs={},
-            source=DUMMY_SOURCE,
             time=time,
         ),
     )

--- a/tests/schedule_sources/test_label_based.py
+++ b/tests/schedule_sources/test_label_based.py
@@ -36,7 +36,6 @@ async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
             labels={"schedule": schedule_label},
             args=[],
             kwargs={},
-            source=source,
         ),
     ]
 

--- a/tests/scheduler/test_label_based_sched.py
+++ b/tests/scheduler/test_label_based_sched.py
@@ -30,8 +30,7 @@ async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
     def task() -> None:
         pass
 
-    source = LabelScheduleSource(broker)
-    schedules = await source.get_schedules()
+    schedules = await LabelScheduleSource(broker).get_schedules()
     assert schedules == [
         ScheduledTask(
             cron=schedule_label[0].get("cron"),
@@ -40,7 +39,6 @@ async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
             labels={"schedule": schedule_label},
             args=[],
             kwargs={},
-            source=source,
         ),
     ]
 


### PR DESCRIPTION
The `source` field in the `TaskiqSchedule` class seemed to be redundant for me. It was adding unnecessary complexity for the extensions API. This change is incompatible with the previous version. 


Signed-off-by: Pavel Kirilin <win10@list.ru>