### PR TITLE
Fixed codecov delta calculations for PRs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Testing taskiq
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
This PR adds test runs on develop and mater branches because it needs to send info to codecov in order to correctly calculate diffs in coverage.