### PR TITLE
Added unschedule possibility.

### DIFF
--- a/docs/examples/extending/schedule_source.py
+++ b/docs/examples/extending/schedule_source.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Coroutine, List
 
 from taskiq import ScheduledTask, ScheduleSource
 
@@ -24,9 +24,13 @@ class MyScheduleSource(ScheduleSource):
 
     # This method is optional. You may not implement this.
     # It's just a helper to people to be able to interact with your source.
-    # This method can be either sync or async.
-    def add_schedule(self, schedule: "ScheduledTask") -> None:
+    async def add_schedule(self, schedule: "ScheduledTask") -> None:
         print("New schedule added:", schedule)
+
+    # This method is completely optional, but if you want to support
+    # schedule cancelation, you must implement it.
+    async def delete_schedule(self, schedule_id: str) -> None:
+        print("Deleting schedule:", schedule_id)
 
     # This method is optional. You may not implement this.
     # It's just a helper to people to be able to interact with your source.

--- a/docs/extending-taskiq/schedule-sources.md
+++ b/docs/extending-taskiq/schedule-sources.md
@@ -10,3 +10,5 @@ To create new `schedule source` you have to implement the `taskiq.abc.schedule_s
 Here's a minimal example of a schedule source:
 
 @[code python](../examples/extending/schedule_source.py)
+
+You can implement a schedule source that write schedules in the database and have delayed tasks in runtime.

--- a/taskiq/abc/schedule_source.py
+++ b/taskiq/abc/schedule_source.py
@@ -18,10 +18,10 @@ class ScheduleSource(ABC):
     async def get_schedules(self) -> List["ScheduledTask"]:
         """Get list of taskiq schedules."""
 
-    def add_schedule(
+    async def add_schedule(
         self,
         schedule: "ScheduledTask",
-    ) -> Union[None, Coroutine[Any, Any, None]]:
+    ) -> None:
         """
         Add a new schedule.
 
@@ -38,6 +38,19 @@ class ScheduleSource(ABC):
         """
         raise NotImplementedError(
             f"The source {self.__class__.__name__} does not support adding schedules.",
+        )
+
+    async def delete_schedule(self, schedule_id: str) -> None:
+        """
+        Method to delete schedule by id.
+
+        This is useful for schedule cancelation.
+
+        :param schedule_id: id of schedule to delete.
+        """
+        raise NotImplementedError(
+            f"The source {self.__class__.__name__} does "
+            "not support deleting schedules.",
         )
 
     def pre_send(  # noqa: B027

--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -14,6 +14,7 @@ from typing import (
 from typing_extensions import ParamSpec
 
 from taskiq.kicker import AsyncKicker
+from taskiq.scheduler.created_schedule import CreatedSchedule
 from taskiq.task import AsyncTaskiqTask
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -103,7 +104,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         cron: Union[str, "CronSpec"],
         *args: _FuncParams.args,
         **kwargs: _FuncParams.kwargs,
-    ) -> None:
+    ) -> CreatedSchedule[_ReturnType]:
         """
         Schedule task to run on cron.
 
@@ -114,8 +115,9 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         :param cron: cron string or a CronSpec instance.
         :param args: function's arguments.
         :param kwargs: function's key word arguments.
+        :return: schedule id.
         """
-        await self.kicker().schedule_cron(
+        return await self.kicker().schedule_by_cron(
             source,
             cron,
             *args,
@@ -128,7 +130,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         time: datetime,
         *args: _FuncParams.args,
         **kwargs: _FuncParams.kwargs,
-    ) -> None:
+    ) -> CreatedSchedule[_ReturnType]:
         """
         Schedule task to run on specific time.
 
@@ -139,8 +141,9 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         :param time: time to run task.
         :param args: function's arguments.
         :param kwargs: function's key word arguments.
+        :return: schedule id.
         """
-        await self.kicker().schedule_time(
+        return await self.kicker().schedule_by_time(
             source,
             time,
             *args,

--- a/taskiq/scheduler/created_schedule.py
+++ b/taskiq/scheduler/created_schedule.py
@@ -1,0 +1,59 @@
+from typing import TYPE_CHECKING, Any, Coroutine, Generic, TypeVar, overload
+
+from taskiq.abc.schedule_source import ScheduleSource
+from taskiq.scheduler.scheduled_task import ScheduledTask
+from taskiq.task import AsyncTaskiqTask
+
+if TYPE_CHECKING:
+    from taskiq.kicker import AsyncKicker
+
+_ReturnType = TypeVar("_ReturnType")
+_T = TypeVar("_T")
+
+
+class CreatedSchedule(Generic[_ReturnType]):
+    """A schedule that has been created."""
+
+    def __init__(
+        self,
+        kicker: "AsyncKicker[Any,_ReturnType]",
+        source: ScheduleSource,
+        task: ScheduledTask,
+    ) -> None:
+        self.kicker = kicker
+        self.source = source
+        self.task = task
+        self.schedule_id = task.schedule_id
+
+    @overload
+    async def kiq(
+        self: "CreatedSchedule[Coroutine[Any,Any, _T]]",
+    ) -> AsyncTaskiqTask[_T]:
+        ...
+
+    @overload
+    async def kiq(self: "CreatedSchedule[_ReturnType]") -> AsyncTaskiqTask[_ReturnType]:
+        ...
+
+    async def kiq(self) -> Any:
+        """Kick the task as if you were not scheduling it."""
+        return await self.kicker.kiq(
+            *self.task.args,
+            **self.task.kwargs,
+        )
+
+    async def unschedule(self) -> None:
+        """Unschedule the task."""
+        await self.source.delete_schedule(self.task.schedule_id)
+
+    def __str__(self) -> str:
+        return (
+            "CreatedSchedule("
+            f"id={self.schedule_id}, "
+            f"time={self.task.time}, "
+            f"cron={self.task.cron}, "
+            f"cron_offset={self.task.cron_offset or 'UTC'}, "
+            f"task_name={self.task.task_name}, "
+            f"args={self.task.args}, "
+            f"kwargs={self.task.kwargs})"
+        )

--- a/taskiq/scheduler/scheduled_task.py
+++ b/taskiq/scheduler/scheduled_task.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
@@ -28,6 +29,7 @@ class ScheduledTask:
     labels: Dict[str, Any]
     args: List[Any]
     kwargs: Dict[str, Any]
+    schedule_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     cron: Optional[str] = field(default=None)
     cron_offset: Optional[Union[str, timedelta]] = field(default=None)
     time: Optional[datetime] = field(default=None)

--- a/tests/schedule_sources/test_label_based.py
+++ b/tests/schedule_sources/test_label_based.py
@@ -30,6 +30,7 @@ async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
     schedules = await source.get_schedules()
     assert schedules == [
         ScheduledTask(
+            schedule_id=schedules[0].schedule_id,
             cron=schedule_label[0].get("cron"),
             time=schedule_label[0].get("time"),
             task_name="test_task",

--- a/tests/scheduler/test_label_based_sched.py
+++ b/tests/scheduler/test_label_based_sched.py
@@ -34,6 +34,7 @@ async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
     schedules = await LabelScheduleSource(broker).get_schedules()
     assert schedules == [
         ScheduledTask(
+            schedule_id=schedules[0].schedule_id,
             cron=schedule_label[0].get("cron"),
             time=schedule_label[0].get("time"),
             task_name="test_task",


### PR DESCRIPTION
This PR adds new abstraction called "CreatedSchedule". When `schedule_*` methods are called, the `CreatedSchedule` is returned. This class has methods to unschedule previously scheduled tasks.

Also, we added new method to the schedule source to remove schedules. To make this method easy to implement, we had to once again add new field `schedule_id` to the `ScheduledTask`. To make it backward compatible though, we made it with default_factory.