### PR TITLE
Add scheduler pre_send exception handling

### DIFF
--- a/docs/examples/extending/schedule_source.py
+++ b/docs/examples/extending/schedule_source.py
@@ -38,6 +38,9 @@ class MyScheduleSource(ScheduleSource):
         """
         Actions to execute before task will be sent to broker.
 
+        This method may raise ScheduledTaskCancelledError.
+        This cancels the task execution.
+
         :param task: task that will be sent
         """
 

--- a/taskiq/abc/schedule_source.py
+++ b/taskiq/abc/schedule_source.py
@@ -60,6 +60,9 @@ class ScheduleSource(ABC):
         """
         Actions to execute before task will be sent to broker.
 
+        This method may raise ScheduledTaskCancelledError.
+        This cancels the task execution.
+
         :param task: task that will be sent
         """
 

--- a/taskiq/exceptions.py
+++ b/taskiq/exceptions.py
@@ -40,3 +40,7 @@ class NoResultError(TaskiqError):
 
 class TaskRejectedError(TaskiqError):
     """Task was rejected."""
+
+
+class ScheduledTaskCancelledError(TaskiqError):
+    """Scheduled task was cancelled and not sent to the queue."""

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1,0 +1,38 @@
+from typing import Any, Coroutine, List, Union
+
+import pytest
+
+from taskiq.abc.schedule_source import ScheduleSource
+from taskiq.brokers.inmemory_broker import InMemoryBroker
+from taskiq.exceptions import ScheduledTaskCancelledError
+from taskiq.scheduler.scheduled_task import ScheduledTask
+from taskiq.scheduler.scheduler import TaskiqScheduler
+
+
+class CancellingScheduleSource(ScheduleSource):
+    async def get_schedules(self) -> List["ScheduledTask"]:
+        """Return schedules list."""
+        return []
+
+    def pre_send(
+        self,
+        task: "ScheduledTask",
+    ) -> Union[None, Coroutine[Any, Any, None]]:
+        """Raise cancelled error."""
+        raise ScheduledTaskCancelledError
+
+
+@pytest.mark.anyio
+async def test_scheduled_task_cancelled() -> None:
+    broker = InMemoryBroker()
+    source = CancellingScheduleSource()
+    scheduler = TaskiqScheduler(broker=broker, sources=[source])
+    task = ScheduledTask(
+        task_name="ping:pong",
+        labels={},
+        args=[],
+        kwargs={},
+        cron="* * * * *",
+    )
+
+    await scheduler.on_ready(source, task)  # error is caught


### PR DESCRIPTION
Followup to #244.

This PR implements a new exception `ScheduledTaskCancelledError` which can be raised in `ScheduleSource.pre_send` method.

This exception is then caught and processed in `TaskiqScheduler.on_ready`. This way, schedule source can decide upon invocation whether the task should be actually performed or not.