### PR TITLE
Set uvloop for current thread explicitly.

### DIFF
--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -117,7 +117,9 @@ def start_listen(args: WorkerArgs, event: Event) -> None:
         loop = uvloop.new_event_loop()  # type: ignore
     else:
         loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+
+    asyncio.set_event_loop(loop)
+
     # This option signals that current
     # broker is running as a worker.
     # We must set this field before importing tasks,


### PR DESCRIPTION
Should help fix a similar problem to #229, but in the case of using uvloop.

I caught this problem on python3.8 with uvloop.