### PR TITLE
Periodic tasks on top of the per-second main loop runner

### DIFF
--- a/taskiq/kicker.py
+++ b/taskiq/kicker.py
@@ -214,6 +214,34 @@ class AsyncKicker(Generic[_FuncParams, _ReturnType]):
         await source.add_schedule(scheduled)
         return CreatedSchedule(self, source, scheduled)
 
+    async def schedule_by_period(
+        self,
+        source: "ScheduleSource",
+        period: Union[float],
+        *args: _FuncParams.args,
+        **kwargs: _FuncParams.kwargs,
+    ) -> CreatedSchedule[_ReturnType]:
+        """
+        Function to schedule task to run periodically.
+
+        :param source: schedule source.
+        :param period: period to run the tasks at.
+        :param args: function's args.
+        :param kwargs: function's kwargs.
+        """
+        schedule_id = self.broker.id_generator()
+        message = self._prepare_message(*args, **kwargs)
+        scheduled = ScheduledTask(
+            schedule_id=schedule_id,
+            task_name=message.task_name,
+            labels=message.labels,
+            args=message.args,
+            kwargs=message.kwargs,
+            period=int(period),
+        )
+        await source.add_schedule(scheduled)
+        return CreatedSchedule(self, source, scheduled)
+
     @classmethod
     def _prepare_arg(cls, arg: Any) -> Any:
         """

--- a/taskiq/schedule_sources/label_based.py
+++ b/taskiq/schedule_sources/label_based.py
@@ -31,7 +31,7 @@ class LabelScheduleSource(ScheduleSource):
             if task.broker != self.broker:
                 continue
             for schedule in task.labels.get("schedule", []):
-                if "cron" not in schedule and "time" not in schedule:
+                if all(field not in schedule for field in ("cron", "time", "period")):
                     continue
                 labels = schedule.get("labels", {})
                 labels.update(task.labels)
@@ -43,6 +43,7 @@ class LabelScheduleSource(ScheduleSource):
                         kwargs=schedule.get("kwargs", {}),
                         cron=schedule.get("cron"),
                         time=schedule.get("time"),
+                        period=schedule.get("period"),
                         cron_offset=schedule.get("cron_offset"),
                     ),
                 )

--- a/taskiq/scheduler/created_schedule.py
+++ b/taskiq/scheduler/created_schedule.py
@@ -52,6 +52,7 @@ class CreatedSchedule(Generic[_ReturnType]):
             f"id={self.schedule_id}, "
             f"time={self.task.time}, "
             f"cron={self.task.cron}, "
+            f"period={self.task.period}, "
             f"cron_offset={self.task.cron_offset or 'UTC'}, "
             f"task_name={self.task.task_name}, "
             f"args={self.task.args}, "

--- a/taskiq/scheduler/scheduled_task/v1.py
+++ b/taskiq/scheduler/scheduled_task/v1.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, root_validator
 
+from taskiq.utils import get_present_object_fields
+
 
 class ScheduledTask(BaseModel):
     """Abstraction over task schedule."""
@@ -16,6 +18,7 @@ class ScheduledTask(BaseModel):
     cron: Optional[str] = None
     cron_offset: Optional[Union[str, timedelta]] = None
     time: Optional[datetime] = None
+    period: Optional[float | int] = None
 
     @root_validator(pre=False)  # type: ignore
     @classmethod
@@ -25,6 +28,9 @@ class ScheduledTask(BaseModel):
 
         :raises ValueError: if cron and time are none.
         """
-        if values.get("cron") is None and values.get("time") is None:
-            raise ValueError("Either cron or datetime must be present.")
+        required_fields = ("cron", "time", "period")
+        present_fields = get_present_object_fields(values, required_fields)
+        if not present_fields:
+            message = f"At least one of {required_fields} must be set."
+            raise ValueError(message)
         return values

--- a/taskiq/scheduler/scheduled_task/v2.py
+++ b/taskiq/scheduler/scheduled_task/v2.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import Self
 
+from taskiq.utils import get_present_object_fields
+
 
 class ScheduledTask(BaseModel):
     """Abstraction over task schedule."""
@@ -17,6 +19,7 @@ class ScheduledTask(BaseModel):
     cron: Optional[str] = None
     cron_offset: Optional[Union[str, timedelta]] = None
     time: Optional[datetime] = None
+    period: Optional[Union[float, int]] = None
 
     @model_validator(mode="after")
     def __check(self) -> Self:
@@ -25,6 +28,9 @@ class ScheduledTask(BaseModel):
 
         :raises ValueError: if cron and time are none.
         """
-        if self.cron is None and self.time is None:
-            raise ValueError("Either cron or datetime must be present.")
+        required_fields = ("cron", "time", "period")
+        present_fields = get_present_object_fields(self, required_fields)
+        if not present_fields:
+            message = f"At least one of {required_fields} must be set."
+            raise ValueError(message)
         return self

--- a/taskiq/scheduler/scheduler.py
+++ b/taskiq/scheduler/scheduler.py
@@ -37,7 +37,7 @@ class TaskiqScheduler:
         """
         This method is called when task is ready to be enqueued.
 
-        It's triggered on proper time depending on `task.cron` or `task.time` attribute.
+        It's triggered on proper time depending on a task.{cron,time,period} attribute.
         :param source: source that triggered this event.
         :param task: task to send
         """

--- a/taskiq/utils.py
+++ b/taskiq/utils.py
@@ -1,5 +1,16 @@
 import inspect
-from typing import Any, Awaitable, Coroutine, TypeVar, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 _T = TypeVar("_T")
 
@@ -35,3 +46,37 @@ def remove_suffix(text: str, suffix: str) -> str:
     if text.endswith(suffix):
         return text[: -len(suffix)]
     return text
+
+
+def get_present_object_fields(
+    obj: Any,
+    fields: Sequence[str],
+    check_condition: Optional[Callable[[Any, str], bool]] = None,
+) -> List[str]:
+    """
+    Check the presence of the fields in the object.
+
+    :param obj: Object to check fields in
+    :param fields: Sequence of fields
+    :param check_condition: A function to check the value is considered present
+    :return: present fields.
+    """
+    if not check_condition:
+        if isinstance(obj, dict):
+
+            def check_condition(obj: Dict[str, Any], field: str) -> bool:
+                return field in obj and obj[field] is not None
+
+        else:
+
+            def check_condition(obj: Any, field: str) -> bool:
+                return getattr(obj, field, None) is not None
+
+    present_fields = []
+    for field in fields:
+        try:
+            if check_condition(obj, field):
+                present_fields.append(field)
+        except AttributeError:
+            pass
+    return present_fields

--- a/tests/schedule_sources/test_label_based.py
+++ b/tests/schedule_sources/test_label_based.py
@@ -14,6 +14,7 @@ from taskiq.scheduler.scheduled_task import ScheduledTask
     [
         pytest.param([{"cron": "* * * * *"}], id="cron"),
         pytest.param([{"time": datetime.utcnow()}], id="time"),
+        pytest.param([{"period": 1.0}], id="period"),
     ],
 )
 async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
@@ -33,6 +34,7 @@ async def test_label_discovery(schedule_label: List[Dict[str, Any]]) -> None:
             schedule_id=schedules[0].schedule_id,
             cron=schedule_label[0].get("cron"),
             time=schedule_label[0].get("time"),
+            period=schedule_label[0].get("period"),
             task_name="test_task",
             labels={"schedule": schedule_label},
             args=[],


### PR DESCRIPTION
Changes:
1) Per-second main event loop cycle;
2) ScheduledTask.period field is added;
3) Periodic tasks execution feature has been added

The example to run the feature against is `main_test.py` in the root directory:

```
# # broker.py
import asyncio
from taskiq.brokers.inmemory_broker import InMemoryBroker

from taskiq.schedule_sources import LabelScheduleSource
from taskiq import TaskiqScheduler

broker = InMemoryBroker()

scheduler = TaskiqScheduler(
    broker=broker,
    sources=[LabelScheduleSource(broker)],
)


@broker.task(schedule=[{"cron": "* * * * *", "args": [1]}])
async def each_minute_cron(value: int) -> int:
    print(f"The {each_minute_cron.__qualname__} task has been launched")
    await asyncio.sleep(0.5)
    return value + 1


@broker.task(schedule=[{"period": 2, "args": [1]}])
async def each_2_seconds_task(value: int) -> int:
    print(f"The {each_2_seconds_task.__qualname__} task has been launched")
    await asyncio.sleep(0.5)
    return value + 1

```