### PR TITLE
Update progress_tracker.py

### DIFF
--- a/taskiq/depends/progress_tracker.py
+++ b/taskiq/depends/progress_tracker.py
@@ -31,6 +31,9 @@ class TaskProgress(GenericModel, Generic[_ProgressType]):
     state: Union[TaskState, str]
     meta: Optional[_ProgressType]
 
+    class Config:
+        arbitrary_types_allowed = True
+
 
 class ProgressTracker(Generic[_ProgressType]):
     """Task's dependency to set progress."""


### PR DESCRIPTION
This allows pydantic 2.7 to pass core schema generation when no default is provided to TaskProgress class.