### PR TITLE
fix: sync decorators

### DIFF
--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -267,8 +267,16 @@ class Receiver:
             if timeout is not None:
                 if not is_coroutine:
                     logger.warning("Timeouts for sync tasks don't work in python well.")
-                target_future = asyncio.wait_for(target_future, float(timeout))
-            returned = await target_future
+
+                with anyio.fail_after(float(timeout)):
+                    while inspect.isawaitable(target_future):
+                        target_future = await target_future
+
+            else:
+                while inspect.isawaitable(target_future):
+                    target_future = await target_future
+
+            returned = target_future
         except NoResultError as no_res_exc:
             found_exception = no_res_exc
             logger.warning(


### PR DESCRIPTION
use case
```[python]
@broker.task()
@validate_call()
async def task(arg1: str) -> None: ...
```

so, the thing is that pydantic's `validator_call` is syncronious decorator which returns awaitable future after call
right now receiver can't work with sync decorators on async functions

