### PR TITLE
Added on_send_error middleware hook

### DIFF
--- a/taskiq/abc/middleware.py
+++ b/taskiq/abc/middleware.py
@@ -131,7 +131,7 @@ class TaskiqMiddleware:  # pragma: no cover
         self,
         message: "TaskiqMessage",
         broker_message: "BrokerMessage",
-        exception: BaseException,
+        exception: Exception,
     ) -> "Union[Union[bool, None], Coroutine[Any, Any, Union[bool, None]]]":
         """
         This function is called when exception is raised while sending a message.
@@ -139,6 +139,9 @@ class TaskiqMiddleware:  # pragma: no cover
         In most cases, it would be a connection issue from the broker.
 
         Any exceptions occurred by broker's formatter will not trigger this.
+
+        SystemExit, KeyboardInterrupt as well as other BaseExceptions will not
+        be caught here as it would be essentially meaningless to catch them.
 
         :param message: the sending TaskiqMessage (not BrokerMessage)
         :param broker_message: the sending BrokerMessage (not TaskiqMessage)

--- a/taskiq/abc/middleware.py
+++ b/taskiq/abc/middleware.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, Coroutine, Union
 
 if TYPE_CHECKING:  # pragma: no cover  # pragma: no cover
     from taskiq.abc.broker import AsyncBroker
-    from taskiq.message import TaskiqMessage
+    from taskiq.message import BrokerMessage, TaskiqMessage
     from taskiq.result import TaskiqResult
 
 
@@ -125,4 +125,23 @@ class TaskiqMiddleware:  # pragma: no cover
         :param message: incoming message.
         :param result: returned value.
         :param exception: found exception.
+        """
+
+    def on_send_error(
+        self,
+        message: "TaskiqMessage",
+        broker_message: "BrokerMessage",
+        exception: BaseException,
+    ) -> "Union[Union[bool, None], Coroutine[Any, Any, Union[bool, None]]]":
+        """
+        This function is called when exception is raised while sending a message.
+
+        In most cases, it would be a connection issue from the broker.
+
+        Any exceptions occurred by broker's formatter will not trigger this.
+
+        :param message: the sending TaskiqMessage (not BrokerMessage)
+        :param broker_message: the sending BrokerMessage (not TaskiqMessage)
+        :param exception: exception, not yet wrapped with SendTaskError
+        :return: True if the error should be omitted, False or None otherwise.
         """

--- a/taskiq/kicker.py
+++ b/taskiq/kicker.py
@@ -134,10 +134,28 @@ class AsyncKicker(Generic[_FuncParams, _ReturnType]):
         for middleware in self.broker.middlewares:
             if middleware.__class__.pre_send != TaskiqMiddleware.pre_send:
                 message = await maybe_awaitable(middleware.pre_send(message))
+
+        broker_message = self.broker.formatter.dumps(message)
         try:
-            await self.broker.kick(self.broker.formatter.dumps(message))
+            await self.broker.kick(broker_message)
         except Exception as exc:
-            raise SendTaskError from exc
+            omitting = False
+            for middleware in reversed(self.broker.middlewares):
+                if middleware.__class__.on_send_error != TaskiqMiddleware.on_send_error:
+                    omitting = (
+                        bool(
+                            await maybe_awaitable(
+                                middleware.on_send_error(
+                                    message,
+                                    broker_message,
+                                    exc,
+                                ),
+                            ),
+                        )
+                        or omitting
+                    )
+            if not omitting:
+                raise SendTaskError from exc
 
         for middleware in self.broker.middlewares:
             if middleware.__class__.post_send != TaskiqMiddleware.post_send:

--- a/tests/middlewares/test_hooks.py
+++ b/tests/middlewares/test_hooks.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import pytest
+
+from taskiq.abc.middleware import TaskiqMiddleware
+from taskiq.brokers.inmemory_broker import InMemoryBroker
+from taskiq.exceptions import SendTaskError
+from taskiq.message import BrokerMessage, TaskiqMessage
+
+
+@pytest.mark.anyio
+async def test_on_send_error() -> None:
+    caught = []
+
+    class _TestMiddleware(TaskiqMiddleware):
+        def on_send_error(
+            self,
+            message: "TaskiqMessage",
+            broker_message: "BrokerMessage",
+            exception: BaseException,
+        ) -> bool:
+            caught.append(1)
+            return True
+
+    broker = InMemoryBroker().with_middlewares(_TestMiddleware())
+
+    broker.kick = lambda *args, **kwargs: (_ for _ in ()).throw(Exception("test"))  # type: ignore
+
+    await broker.startup()
+    await broker.task(lambda: None).kiq()
+    await broker.shutdown()
+
+    assert caught == [1]
+
+
+@pytest.mark.anyio
+async def test_on_send_error_raise() -> None:
+    caught = []
+
+    class _TestMiddleware(TaskiqMiddleware):
+        def on_send_error(
+            self,
+            message: "TaskiqMessage",
+            broker_message: "BrokerMessage",
+            exception: BaseException,
+        ) -> None:
+            caught.append(0)
+
+    broker = InMemoryBroker().with_middlewares(_TestMiddleware())
+
+    broker.kick = lambda *args, **kwargs: (_ for _ in ()).throw(Exception("test"))  # type: ignore
+
+    await broker.startup()
+
+    with pytest.raises(SendTaskError):
+        await broker.task(lambda: None).kiq()
+
+    await broker.shutdown()
+
+    assert caught == [0]
+
+
+@pytest.mark.anyio
+async def test_on_send_error_inverted() -> None:
+    caught = []
+
+    class _TestMiddleware1(TaskiqMiddleware):
+        def on_send_error(
+            self,
+            message: "TaskiqMessage",
+            broker_message: "BrokerMessage",
+            exception: BaseException,
+        ) -> bool:
+            caught.append(1)
+            return True
+
+    class _TestMiddleware2(TaskiqMiddleware):
+        async def on_send_error(
+            self,
+            message: "TaskiqMessage",
+            broker_message: "BrokerMessage",
+            exception: BaseException,
+        ) -> bool:
+            await asyncio.sleep(0)
+            caught.append(2)
+            return True
+
+    broker = InMemoryBroker().with_middlewares(_TestMiddleware1(), _TestMiddleware2())
+
+    broker.kick = lambda *args, **kwargs: (_ for _ in ()).throw(Exception("test"))  # type: ignore
+
+    await broker.startup()
+    await broker.task(lambda: None).kiq()
+    await broker.shutdown()
+
+    assert caught == [2, 1]


### PR DESCRIPTION
Hi,

I am currently working on a retrying feature to ensure the delivery of messages when the queue service is unstable. I found that it could be really helpful to have this `on_send_error` so that we can store the failed message and retry later.

I've also added a `bool` return to make it able to mute exceptions so that we don't have to try-catch the kicking everywhere.

The execution order of `on_send_error` is reversed, just like what I suggested in https://github.com/taskiq-python/taskiq/pull/359 .

Please let me know if you have some ideas, suggestions or concerns, and big thanks in advance!