### PR TITLE
Set right command for install environment for contribution

### DIFF
--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -21,7 +21,7 @@ We use poetry for managing dependencies. To install it, please follow the offici
 After you have cloned the taskiq repo, install dependencies using this command:
 
 ```bash
-poetry install
+poetry install --all-extras
 ```
 
 It will install all required dependencies.


### PR DESCRIPTION
Today I decide to dive into taskiq and take some issue for resolving. When I set up local environment I meet problems with command:
```bash
pytest
```

in `Tesing` section, output was:
```shell
(.venv) mukhamux ~/own/taskiq [master] $ pytest                   
========================================================================================================= test session starts ==========================================================================================================
platform darwin -- Python 3.12.6, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/mukhamux/own/taskiq
configfile: pyproject.toml
plugins: xdist-2.5.0, anyio-4.4.0, mock-3.14.0, forked-1.6.0, cov-3.0.0
collected 130 items / 1 error                                                                                                                                                                                                          

================================================================================================================ ERRORS ================================================================================================================
________________________________________________________________________________________ ERROR collecting tests/serializers/test_serializers.py ________________________________________________________________________________________
ImportError while importing test module '/Users/mukhamux/own/taskiq/tests/serializers/test_serializers.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/serializers/test_serializers.py:22: in <module>
    ORJSONSerializer(),
taskiq/serializers/orjson_serializer.py:20: in __init__
    raise ImportError("orjson is not installed")
E   ImportError: orjson is not installed
=========================================================================================================== warnings summary ===========================================================================================================
tests/schedule_sources/test_label_based.py:16
  /Users/mukhamux/own/taskiq/tests/schedule_sources/test_label_based.py:16: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    pytest.param([{"time": datetime.utcnow()}], id="time"),

tests/scheduler/test_label_based_sched.py:21
  /Users/mukhamux/own/taskiq/tests/scheduler/test_label_based_sched.py:21: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    pytest.param([{"time": datetime.utcnow()}], id="time"),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================= short test summary info ========================================================================================================
ERROR tests/serializers/test_serializers.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================================================================================== 2 warnings, 1 error in 0.12s =====================================================================================================
```

but there are orjson in pyproject.toml 🤔
When I execute
```bash
poetry install --all-extras
```

instead of
```bash
poetry install
```

all tests passed