### PR TITLE
Do not ACK errored messages

### DIFF
--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -144,7 +144,15 @@ class Receiver:
             message,
             AckableMessage,
         ):
-            await maybe_awaitable(message.ack())
+            if not result.is_err:
+                await maybe_awaitable(message.ack())
+            else:
+                # Do not acknowledge the message
+                logger.error(
+                    "Task %s with ID %s failed. Message not acknowledged.",
+                    taskiq_msg.task_name,
+                    taskiq_msg.task_id,
+                )
 
         result = await self.run_task(
             target=task.original_func,
@@ -155,7 +163,15 @@ class Receiver:
             message,
             AckableMessage,
         ):
-            await maybe_awaitable(message.ack())
+            if not result.is_err:
+                await maybe_awaitable(message.ack())
+            else:
+                # Do not acknowledge the message
+                logger.error(
+                    "Task %s with ID %s failed. Message not acknowledged.",
+                    taskiq_msg.task_name,
+                    taskiq_msg.task_id,
+                )
 
         for middleware in self.broker.middlewares:
             if middleware.__class__.post_execute != TaskiqMiddleware.post_execute:
@@ -182,7 +198,15 @@ class Receiver:
             message,
             AckableMessage,
         ):
-            await maybe_awaitable(message.ack())
+            if not result.is_err:
+                await maybe_awaitable(message.ack())
+            else:
+                # Do not acknowledge the message
+                logger.error(
+                    "Task %s with ID %s failed. Message not acknowledged.",
+                    taskiq_msg.task_name,
+                    taskiq_msg.task_id,
+                )
 
     async def run_task(  # noqa: C901, PLR0912, PLR0915
         self,


### PR DESCRIPTION
I had an issue with my FastAPI project where a task was throwing an exception and yet the message was being acknowledged and lost forever. I tried using the context inside the task to reject the message as shown [here](https://taskiq-python.github.io/guide/architecture-overview.html#context), but the task seemed to hang while trying to resolve the context dependency. I ended up implementing a fix I'll describe below.

For reference, here's a simplified version of my code:
```python
# broker.py
import taskiq_fastapi
from taskiq_aio_pika import AioPikaBroker

from settings import settings

broker = AioPikaBroker(
    settings.rabbit_dsn,
    queue_name=f"myapp_{settings.environment}",
    exchange_name=f"myapp_{settings.environment}",
    dead_letter_queue_name=f"myapp_{settings.environment}.dead_letter",
    delay_queue_name=f"myapp_{settings.environment}.delay",
    qos=1,  # Consume one message at a time
)
```

```python
# myservice.py
@broker.task
async def store(
    task_data,
) -> None:
    service = SomeService()
    data = await service.fetch_data_rpc(
        task_data
    )
```

Here, the `fetch_data_rpc` inside my task throws an exception. I'd expect the message to be requeued, sent to the dead letter configured in the broker, or at least not acknowledged, but that is not the case.

I'm not sure if this is an issue or an intended behavior, as I can see that in your `receiver.py` all messages are acknowledged regardless of their errors.
```python
if self.ack_time == AcknowledgeType.WHEN_RECEIVED and isinstance(
    message,
    AckableMessage,
):
    await maybe_awaitable(message.ack())
```

This may be related with [this issue](https://github.com/taskiq-python/taskiq/issues/322),

In the end, my solution was to wrap the ACK in an if that checks if the message had errors. Now, if a task fails, the message is not acknowledged. This solves my issue, as failed messages are not lost now.

I'm sending my fix as a PR in case you consider it useful for use cases other than mine.