### PR TITLE
support discovering pyc/pyd/so modules

### DIFF
--- a/taskiq/cli/utils.py
+++ b/taskiq/cli/utils.py
@@ -94,7 +94,7 @@ def import_tasks(
                         # remove all suffixes
                         prefix = path.name.partition(".")[0]
                         discovered_modules.add(
-                            str(path.with_name(prefix)).replace(os.path.sep, ".")
+                            str(path.with_name(prefix)).replace(os.path.sep, "."),
                         )
                     # ignore other files
                 else:

--- a/taskiq/cli/utils.py
+++ b/taskiq/cli/utils.py
@@ -6,8 +6,6 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Generator, List, Sequence, Union
 
-from taskiq.utils import remove_suffix
-
 logger = getLogger("taskiq.worker")
 
 
@@ -91,9 +89,16 @@ def import_tasks(
         discovered_modules = set()
         for glob_pattern in pattern:
             for path in Path().glob(glob_pattern):
-                discovered_modules.add(
-                    remove_suffix(str(path), ".py").replace(os.path.sep, "."),
-                )
+                if path.is_file():
+                    if path.suffix in (".py", ".pyc", ".pyd", ".so"):
+                        # remove all suffixes
+                        prefix = path.name.partition(".")[0]
+                        discovered_modules.add(
+                            str(path.with_name(prefix)).replace(os.path.sep, ".")
+                        )
+                    # ignore other files
+                else:
+                    discovered_modules.add(str(path).replace(os.path.sep, "."))
 
         modules.extend(list(discovered_modules))
     import_from_modules(modules)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from pathlib import Path
 from unittest.mock import patch
 
@@ -66,7 +67,5 @@ def test_import_tasks_non_py_list_pattern() -> None:
             mock.assert_called_with(modules)
         finally:
             for path in pathes:
-                try:
+                with suppress(FileNotFoundError):
                     path.unlink()
-                except FileNotFoundError:
-                    pass


### PR DESCRIPTION
I used Cython to compile the .py files into .so files. However, taskiq can only automatically discover .py files, so I added support for .pyc, .pyd, and .so files.