### PR TITLE
Fixed shutdowns.

### DIFF
--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -44,12 +44,12 @@ async def shutdown_broker(broker: AsyncBroker, timeout: float) -> None:
     try:
         ret_val = await asyncio.wait_for(broker.shutdown(), timeout)  # type: ignore
         if ret_val is not None:
-            logger.info("Broker returned value on shutdown: '%s'", str(ret_val))
+            logger.info("Broker has returned value on shutdown: '%s'", str(ret_val))
     except asyncio.TimeoutError:
-        logger.warning("Cannot shutdown broker gracefully. Timed out.")
+        logger.warning("Broker.shutdown cannot be completed in %s seconds.", timeout)
     except Exception as exc:
         logger.warning(
-            "Exception found while terminating: %s",
+            "Exception found while shutting down broker: %s",
             exc,
             exc_info=True,
         )
@@ -151,8 +151,7 @@ def start_listen(args: WorkerArgs) -> None:
                 **receiver_kwargs,  # type: ignore
             )
             loop.run_until_complete(receiver.listen(shutdown_event))
-    except KeyboardInterrupt:
-        logger.warning("Worker process interrupted.")
+    finally:
         loop.run_until_complete(shutdown_broker(broker, args.shutdown_timeout))
 
 


### PR DESCRIPTION
This PR fixes the way shutdowns are being invoked.

The behavior before this change was correct in previous versions of the shutdown logic. However, I updated the way shutdown events are propagated in #381, and since then, the broker has stopped propagating the `KeyboardInterrupt` exception. As a result, the shutdown() method was not being called.

Fun observation, the hard-kill logic still throws a `KeyboardInterrupt` exception, and if the hard-kill is triggered quickly enough, the shutdown will occur correctly.

Fixes #424.