### PR TITLE
Fix docstring: remove non-existent parameter and correct typos

### DIFF
--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -163,7 +163,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         """
         This function returns kicker object.
 
-        Kicker is a object that can modify kiq request
+        Kicker is an object that can modify kiq request
         before sending it.
 
         :return: AsyncKicker instance.

--- a/taskiq/kicker.py
+++ b/taskiq/kicker.py
@@ -184,7 +184,6 @@ class AsyncKicker(Generic[_FuncParams, _ReturnType]):
         :param source: schedule source.
         :param cron: cron expression.
         :param args: function's args.
-        :param cron_offset: cron offset.
         :param kwargs: function's kwargs.
 
         :return: schedule id.

--- a/taskiq/serialization.py
+++ b/taskiq/serialization.py
@@ -336,7 +336,7 @@ def exception_to_python(
     """Convert serialized exception to Python exception.
 
     :param exc: encoded exception
-    :raises SecurityError: exception isn't indead an exception
+    :raises SecurityError: exception isn't indeed an exception
     :return: decoded exception or None
     """
     if not exc:

--- a/taskiq/task.py
+++ b/taskiq/task.py
@@ -73,7 +73,7 @@ class AsyncTaskiqTask(Generic[_ReturnType]):
         ready. And if it is it returns the result.
 
         It may throw TaskiqResultTimeoutError if
-        task didn't became ready in provided
+        task didn't become ready in provided
         period of time.
 
         :param check_interval: How often checks are performed.


### PR DESCRIPTION
This PR removes a non-existent parameter from the docstring and fixes spelling errors within it.