### PR TITLE
fix: log configuring when running under spawn and add --log-format

### DIFF
--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -30,6 +30,7 @@ class WorkerArgs:
     fs_discover: bool = False
     configure_logging: bool = True
     log_level: LogLevel = LogLevel.INFO
+    log_format: str = "[%(asctime)s][%(name)s][%(levelname)-7s][%(processName)s] %(message)s"
     workers: int = 2
     max_threadpool_threads: Optional[int] = None
     max_process_pool_processes: Optional[int] = None
@@ -117,6 +118,11 @@ class WorkerArgs:
             default="INFO",
             choices=[level.name for level in LogLevel],
             help="worker log level",
+        )
+        parser.add_argument(
+            "--log-format",
+            default="[%(asctime)s][%(name)s][%(levelname)-7s][%(processName)s] %(message)s",
+            help="worker log format",
         )
         parser.add_argument(
             "--workers",

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -30,7 +30,9 @@ class WorkerArgs:
     fs_discover: bool = False
     configure_logging: bool = True
     log_level: LogLevel = LogLevel.INFO
-    log_format: str = "[%(asctime)s][%(name)s][%(levelname)-7s][%(processName)s] %(message)s"
+    log_format: str = (
+        "[%(asctime)s][%(name)s][%(levelname)-7s][%(processName)s] %(message)s"
+    )
     workers: int = 2
     max_threadpool_threads: Optional[int] = None
     max_process_pool_processes: Optional[int] = None
@@ -121,7 +123,8 @@ class WorkerArgs:
         )
         parser.add_argument(
             "--log-format",
-            default="[%(asctime)s][%(name)s][%(levelname)-7s][%(processName)s] %(message)s",
+            default="[%(asctime)s][%(name)s][%(levelname)-7s]"
+            "[%(processName)s] %(message)s",
             help="worker log format",
         )
         parser.add_argument(

--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -5,7 +5,7 @@ import os
 import signal
 import sys
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
-from multiprocessing import set_start_method
+from multiprocessing import set_start_method, get_start_method
 from sys import platform
 from typing import Any, Optional, Type
 
@@ -86,7 +86,11 @@ def start_listen(args: WorkerArgs) -> None:
     """
     shutdown_event = asyncio.Event()
     hardkill_counter = 0
-
+    if args.configure_logging and get_start_method() == "spawn":
+        logging.basicConfig(
+            level=logging.getLevelName(args.log_level),
+            format=args.log_format,
+        )
     def interrupt_handler(signum: int, _frame: Any) -> None:
         """
         Signal handler.
@@ -186,8 +190,7 @@ def run_worker(args: WorkerArgs) -> Optional[int]:
     if args.configure_logging:
         logging.basicConfig(
             level=logging.getLevelName(args.log_level),
-            format="[%(asctime)s][%(name)s][%(levelname)-7s]"
-            "[%(processName)s] %(message)s",
+            format=args.log_format,
         )
     logging.getLogger("taskiq").setLevel(level=logging.getLevelName(args.log_level))
     logging.getLogger("watchdog.observers.inotify_buffer").setLevel(level=logging.INFO)

--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -5,7 +5,7 @@ import os
 import signal
 import sys
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
-from multiprocessing import set_start_method, get_start_method
+from multiprocessing import get_start_method, set_start_method
 from sys import platform
 from typing import Any, Optional, Type
 
@@ -91,6 +91,7 @@ def start_listen(args: WorkerArgs) -> None:
             level=logging.getLevelName(args.log_level),
             format=args.log_format,
         )
+
     def interrupt_handler(signum: int, _frame: Any) -> None:
         """
         Signal handler.


### PR DESCRIPTION
**Technical explanation of the issue:**

1. When using 'fork', a copy of the current process is created, including memory and state of all objects. This means logging settings are preserved.
2. When using 'spawn', a new process is created which imports modules fresh. This means all global objects, including loggers, are initialized again.

**Problem in taskiq code:**

1. Logging configuration happens in the parent process, but these settings are not passed to child processes when using 'spawn'.
2. DEBUG logs are not visible because by default loggers in child processes have WARNING or INFO level.

**PR fixes:**

1. This PR fixes the logging issue when using the 'spawn' method in multiprocessing
2. Adds log-format support, which allows more flexible configuration of logger behavior when using spawn

Now DEBUG level logs will be correctly displayed in all child processes, even when using the 'spawn' method, and log formatting settings can be easily customized.