### PR TITLE
Add --reload-dir argument

### DIFF
--- a/taskiq/cli/watcher.py
+++ b/taskiq/cli/watcher.py
@@ -14,12 +14,13 @@ class FileWatcher:  # pragma: no cover
     def __init__(
         self,
         callback: Callable[..., None],
+        path: Path,
         use_gitignore: bool = True,
         **callback_kwargs: Any,
     ) -> None:
         self.callback = callback
         self.gitignore = None
-        gpath = Path("./.gitignore")
+        gpath = path / ".gitignore"
         if use_gitignore and gpath.exists():
             self.gitignore = parse_gitignore(gpath)
         self.callback_kwargs = callback_kwargs

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -39,6 +39,7 @@ class WorkerArgs:
     no_parse: bool = False
     shutdown_timeout: float = 5
     reload: bool = False
+    reload_dirs: List[str] = field(default_factory=list)
     no_gitignore: bool = False
     max_async_tasks: int = 100
     receiver: str = "taskiq.receiver:Receiver"
@@ -171,6 +172,16 @@ class WorkerArgs:
             action="store_true",
             help="Reload workers if file is changed. "
             "`reload` extra is required for this option.",
+        )
+        parser.add_argument(
+            "--reload-dir",
+            action="append",
+            dest="reload_dirs",
+            default=[],
+            help=(
+                "Specify a directory to watch for changes. Can be specified "
+                "multiple times. Defaults to the current working directory."
+            ),
         )
         parser.add_argument(
             "--do-not-use-gitignore",

--- a/taskiq/cli/worker/process_manager.py
+++ b/taskiq/cli/worker/process_manager.py
@@ -166,7 +166,7 @@ class ProcessManager:
         if args.reload and observer is not None:
             watch_paths = args.reload_dirs if args.reload_dirs else ["."]
             for path_to_watch in watch_paths:
-                logger.info(f"Watching directory: {path_to_watch}")
+                logger.debug(f"Watching directory: {path_to_watch}")
                 observer.schedule(
                     FileWatcher(
                         callback=schedule_workers_reload,


### PR DESCRIPTION
This is a small change that partially addresses #318, and allows multiple reload dirs to be specified via the CLI instead of using just the CWD, using the `--reload-dir` option, which can be passed multiple times for multiple reload directories.

Why I need this:
I use TaskIQ with tasks loaded from pip packages that I've installed with `pip install -e path/to/local/package` in development, and am constantly editing and having to manually reload TaskIQ due to the fact that the locally-installed package is outside of the CWD.

- If the --reload-dir option is not passed, the default of using the CWD is still used.
- pytest tests still pass
- Committed with pre-commit hooks installed and working
- Adds a logger.debug of the reload dirs being watched.