### PR TITLE
Add seconds and milliseconds support in cron_offset

### DIFF
--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -85,14 +85,18 @@ def get_task_delay(task: ScheduledTask) -> Optional[int]:
     if task.cron is not None:
         # If user specified cron offset we apply it.
         # If it's timedelta, we simply add the delta to current time.
+        additional_seconds = 0
         if task.cron_offset and isinstance(task.cron_offset, timedelta):
             now += task.cron_offset
+            additional_seconds += int(task.cron_offset.total_seconds() % 60) + (
+                1 if task.cron_offset.microseconds else 0
+            )
         # If timezone was specified as string we convert it timzone
         # offset and then apply.
         elif task.cron_offset and isinstance(task.cron_offset, str):
             now = now.astimezone(pytz.timezone(task.cron_offset))
         if is_now(task.cron, now):
-            return 0
+            return additional_seconds
         return None
     if task.time is not None:
         task_time = to_tz_aware(task.time)

--- a/tests/cli/scheduler/test_task_delays.py
+++ b/tests/cli/scheduler/test_task_delays.py
@@ -150,3 +150,35 @@ def test_time_delay_with_milliseconds() -> None:
         ),
     )
     assert delay is not None and delay == 16
+
+
+@freeze_time("2025-05-22 12:00:00")
+def test_cron_offset_delay_with_seconds() -> None:
+    seconds_offset = 2
+    delay = get_task_delay(
+        ScheduledTask(
+            task_name="",
+            labels={},
+            args=[],
+            kwargs={},
+            cron="* 12 * * *",
+            cron_offset=datetime.timedelta(seconds=seconds_offset),
+        ),
+    )
+    assert delay is not None and delay == seconds_offset
+
+
+@freeze_time("2025-05-22 12:00:00")
+def test_cron_offset_delay_with_seconds_and_milliseconds() -> None:
+    seconds_offset = 2
+    delay = get_task_delay(
+        ScheduledTask(
+            task_name="",
+            labels={},
+            args=[],
+            kwargs={},
+            cron="* 12 * * *",
+            cron_offset=datetime.timedelta(seconds=seconds_offset, milliseconds=1),
+        ),
+    )
+    assert delay is not None and delay == seconds_offset + 1


### PR DESCRIPTION
Cron is insensitive to seconds. But cron_offset accepts datetime.timedelta, which has seconds in it. This PR adds sensitivity to seconds and milliseconds from cron_offset.