### PR TITLE
✨ Added the `--app-dir` param to specify the sources directory

### DIFF
--- a/taskiq/cli/scheduler/args.py
+++ b/taskiq/cli/scheduler/args.py
@@ -12,6 +12,7 @@ class SchedulerArgs:
 
     scheduler: Union[str, TaskiqScheduler]
     modules: List[str]
+    app_dir: Optional[str] = None
     log_level: str = LogLevel.INFO.name
     configure_logging: bool = True
     fs_discover: bool = False
@@ -41,6 +42,16 @@ class SchedulerArgs:
             "modules",
             help="List of modules where to look for tasks.",
             nargs=ZERO_OR_MORE,
+        )
+        parser.add_argument(
+            "--app-dir",
+            "-d",
+            default=None,
+            help=(
+                "Path to application directory. "
+                "This path will be used to import tasks modules. "
+                "If not specified, current working directory will be used."
+            ),
         )
         parser.add_argument(
             "--fs-discover",

--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -249,7 +249,7 @@ async def run_scheduler(args: SchedulerArgs) -> None:
     getLogger("taskiq").setLevel(level=getLevelName(args.log_level))
 
     if isinstance(args.scheduler, str):
-        scheduler = import_object(args.scheduler)
+        scheduler = import_object(args.scheduler, app_dir=args.app_dir)
         if inspect.isfunction(scheduler):
             scheduler = scheduler()
     else:

--- a/taskiq/cli/utils.py
+++ b/taskiq/cli/utils.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from importlib import import_module
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Generator, List, Sequence, Union
+from typing import Any, Generator, List, Sequence, Union, Optional
 
 logger = getLogger("taskiq.worker")
 
@@ -35,11 +35,12 @@ def add_cwd_in_path() -> Generator[None, None, None]:
                 logger.warning(f"Cannot remove '{cwd}' from sys.path")
 
 
-def import_object(object_spec: str) -> Any:
+def import_object(object_spec: str, app_dir: Optional[str] = None) -> Any:
     """
     It parses python object spec and imports it.
 
     :param object_spec: string in format like `package.module:variable`
+    :param app_dir: directory to add in sys.path for importing.
     :raises ValueError: if spec has unknown format.
     :returns: imported broker.
     """
@@ -47,6 +48,8 @@ def import_object(object_spec: str) -> Any:
     if len(import_spec) != 2:
         raise ValueError("You should provide object path in `module:variable` format.")
     with add_cwd_in_path():
+        if app_dir:
+            sys.path.insert(0, app_dir)
         module = import_module(import_spec[0])
     return getattr(module, import_spec[1])
 

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -26,6 +26,7 @@ class WorkerArgs:
 
     broker: str
     modules: List[str]
+    app_dir: Optional[str] = None
     tasks_pattern: Sequence[str] = ("**/tasks.py",)
     fs_discover: bool = False
     configure_logging: bool = True
@@ -71,6 +72,16 @@ class WorkerArgs:
                 "Where to search for broker or broker factory function. "
                 "This string must be specified in "
                 "'module.module:variable' format."
+            ),
+        )
+        parser.add_argument(
+            "--app-dir",
+            "-d",
+            default=None,
+            help=(
+                "Path to application directory. "
+                "This path will be used to import tasks modules. "
+                "If not specified, current working directory will be used."
             ),
         )
         parser.add_argument(

--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -64,7 +64,7 @@ def get_receiver_type(args: WorkerArgs) -> Type[Receiver]:
     :raises ValueError: if receiver is not a Receiver type.
     :return: Receiver type.
     """
-    receiver_type = import_object(args.receiver)
+    receiver_type = import_object(args.receiver, app_dir=args.app_dir)
     if not (isinstance(receiver_type, type) and issubclass(receiver_type, Receiver)):
         raise ValueError("Unknown receiver type. Please use Receiver class.")
     return receiver_type
@@ -133,7 +133,7 @@ def start_listen(args: WorkerArgs) -> None:
     # We must set this field before importing tasks,
     # so broker will remember all tasks it's related to.
 
-    broker = import_object(args.broker)
+    broker = import_object(args.broker, app_dir=args.app_dir)
     if inspect.isfunction(broker):
         broker = broker()
     if not isinstance(broker, AsyncBroker):


### PR DESCRIPTION
### What?
- [x] Add the `--app-dir`/`-d` params in CLI to add the directory to add to `sys.path` before trying to `import_module(...)`.
- [x] Add the `--app-dir`/`-d` to both the Worker and Scheduler.

### Why?
- To support the projects that have a separate sources directory.

### How to test?
- When something lives in `./my_src/my_module.py`, it should be imported with `--app-dir my_src my_module:my_broker`.