### PR TITLE
fix: replace getLevelName with IntEnum for log levels

### DIFF
--- a/taskiq/cli/common_args.py
+++ b/taskiq/cli/common_args.py
@@ -1,11 +1,13 @@
 import enum
+import logging
 
 
-class LogLevel(str, enum.Enum):
+class LogLevel(enum.IntEnum):
     """Different log levels."""
 
-    INFO = "INFO"
-    WARNING = "WARNING"
-    DEBUG = "DEBUG"
-    ERROR = "ERROR"
-    FATAL = "FATAL"
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    DEBUG = logging.DEBUG
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL
+    FATAL = logging.FATAL

--- a/taskiq/cli/scheduler/args.py
+++ b/taskiq/cli/scheduler/args.py
@@ -12,7 +12,7 @@ class SchedulerArgs:
 
     scheduler: Union[str, TaskiqScheduler]
     modules: List[str]
-    log_level: str = LogLevel.INFO.name
+    log_level: LogLevel = LogLevel.INFO
     configure_logging: bool = True
     fs_discover: bool = False
     tasks_pattern: Sequence[str] = ("**/tasks.py",)
@@ -96,4 +96,6 @@ class SchedulerArgs:
         # This is an argparse limitation.
         if len(namespace.tasks_pattern) > 1:
             namespace.tasks_pattern.pop(0)
+        # Convert log_level string to LogLevel enum
+        namespace.log_level = LogLevel[namespace.log_level]
         return cls(**namespace.__dict__)

--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import sys
 from datetime import datetime, timedelta, timezone
-from logging import basicConfig, getLevelName, getLogger
+from logging import basicConfig, getLogger
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pytz
@@ -239,14 +239,14 @@ async def run_scheduler(args: SchedulerArgs) -> None:
     """
     if args.configure_logging:
         basicConfig(
-            level=getLevelName(args.log_level),
+            level=args.log_level,
             format=(
                 "[%(asctime)s][%(levelname)-7s]"
                 "[%(module)s:%(funcName)s:%(lineno)d]"
                 " %(message)s"
             ),
         )
-    getLogger("taskiq").setLevel(level=getLevelName(args.log_level))
+    getLogger("taskiq").setLevel(level=args.log_level)
 
     if isinstance(args.scheduler, str):
         scheduler = import_object(args.scheduler)

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -261,4 +261,6 @@ class WorkerArgs:
         # This is an argparse limitation.
         if len(namespace.tasks_pattern) > 1:
             namespace.tasks_pattern.pop(0)
+        # Convert log_level string to LogLevel enum
+        namespace.log_level = LogLevel[namespace.log_level]
         return WorkerArgs(**namespace.__dict__)

--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -88,7 +88,7 @@ def start_listen(args: WorkerArgs) -> None:
     hardkill_counter = 0
     if args.configure_logging and get_start_method() == "spawn":
         logging.basicConfig(
-            level=logging.getLevelName(args.log_level),
+            level=args.log_level,
             format=args.log_format,
         )
 
@@ -190,10 +190,10 @@ def run_worker(args: WorkerArgs) -> Optional[int]:
         set_start_method("spawn")
     if args.configure_logging:
         logging.basicConfig(
-            level=logging.getLevelName(args.log_level),
+            level=args.log_level,
             format=args.log_format,
         )
-    logging.getLogger("taskiq").setLevel(level=logging.getLevelName(args.log_level))
+    logging.getLogger("taskiq").setLevel(level=args.log_level)
     logging.getLogger("watchdog.observers.inotify_buffer").setLevel(level=logging.INFO)
     logger.info("Pid of a main process: %s", str(os.getpid()))
     logger.info("Starting %s worker processes.", args.workers)


### PR DESCRIPTION
This PR refactors how log levels are handled in the taskiq CLI to avoid using behavior that Python's logging documentation explicitly considers incorrect.

### Background

According to the [Python logging documentation](https://docs.python.org/3/library/logging.html#logging.getLevelName), using `getLevelName()` to convert string level names to integers (like "INFO" to 20) is explicitly "considered a mistake". 

> In Python versions earlier than 3.4, this function could also be passed a text level, and would return the corresponding numeric value of the level. This undocumented behaviour was considered a mistake, and was removed in Python 3.4, but reinstated in 3.4.2 due to retain backward compatibility.

### Changes

This PR refactors the `LogLevel` enum to inherit from `IntEnum` instead of `str`, storing the actual logging module constants (`logging.INFO`, `logging.WARNING`, etc.) as enum values. The enum members are now integers by nature, which can be passed directly to logging functions without any conversion.

Modified files:
- `taskiq/cli/common_args.py`: Changed `LogLevel` to `IntEnum` with logging constant values
- `taskiq/cli/scheduler/args.py`: Added string to enum conversion in argument parsing
- `taskiq/cli/scheduler/run.py`: Updated to use log_level directly as integer
- `taskiq/cli/worker/args.py`: Added string to enum conversion in argument parsing  
- `taskiq/cli/worker/run.py`: Updated to use log_level directly as integer

### Compatibility

The CLI interface remains unchanged. Users can still pass log levels as strings:

```
taskiq worker my_broker --log-level INFO
taskiq scheduler my_scheduler --log-level DEBUG
```

The string is converted to the appropriate `LogLevel` enum member during argument parsing, and since the enum values are integers, they work directly with the logging module.

### Benefits

This approach uses the proper API as intended by Python's logging module. The solution is type safe, and maintains full backward compatibility with existing CLI usage.