### PR TITLE
feat: add optional update_schedule method for ScheduleSource

### DIFF
--- a/docs/examples/extending/schedule_source.py
+++ b/docs/examples/extending/schedule_source.py
@@ -27,6 +27,11 @@ class MyScheduleSource(ScheduleSource):
     async def add_schedule(self, schedule: "ScheduledTask") -> None:
         print("New schedule added:", schedule)
 
+    # This method is optional. You may not implement this.
+    # It's just a helper to people to be able to interact with your source.
+    async def update_schedule(self, schedule: "ScheduledTask") -> None:
+        print("Updating schedule:", schedule.schedule_id)
+
     # This method is completely optional, but if you want to support
     # schedule cancelation, you must implement it.
     async def delete_schedule(self, schedule_id: str) -> None:

--- a/taskiq/abc/schedule_source.py
+++ b/taskiq/abc/schedule_source.py
@@ -42,6 +42,29 @@ class ScheduleSource(ABC):
             f"The source {self.__class__.__name__} does not support adding schedules.",
         )
 
+    async def update_schedule(
+        self,
+        schedule: "ScheduledTask",
+    ) -> None:
+        """
+        Update an existing schedule.
+
+        This function is used to update existing schedules.
+        It's a convenient helper for people who want to update schedules
+        for the current source.
+
+        As an example, if your source works with a database,
+        you may want to update existing rows in the table.
+
+        Note that this function may do nothing.
+
+        :param schedule: schedule to update.
+        """
+        raise NotImplementedError(
+            f"The source {self.__class__.__name__} does "
+            "not support updating schedules.",
+        )
+
     async def delete_schedule(self, schedule_id: str) -> None:
         """
         Method to delete schedule by id.


### PR DESCRIPTION
Added optional `update_schedule` method for `ScheduleSource`.

This method will be simpler to use than delete and then recreate. 