### PR TITLE
Fixed wrongly mentioned exception in getting-started.md

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -246,7 +246,7 @@ await my_task.kicker().with_labels(timeout=0.3).kiq()
 
 ::: caution Cool alert
 
-We use [run_in_executor](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor) method to run sync functions. Timeouts will raise a TimeoutException, but
+We use [run_in_executor](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor) method to run sync functions. Timeouts will raise a TimeoutError, but
 synchronous function may not stop from execution. This is a constraint of python.
 
 :::


### PR DESCRIPTION
### Description
`TimeoutException` is mentioned in [Getting Started > Timeouts](https://taskiq-python.github.io/guide/getting-started.html#timeouts), but it actually doesn't exist. Exceeded task timeout will raise `TimeoutError`, because this is what `asyncio.wait.for()` does.

Sorry for disturbing )