### PR TITLE
docs: fix contributors block

### DIFF
--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Setup Node.js


### PR DESCRIPTION
For contributors block ViePress need full git history so I added `fetch-depth: 0`.

I deployed documentation from my fork to prove that fix woks: https://danfimov.github.io/taskiq/guide/scheduling-tasks.html#dynamic-scheduling
<img width="1161" height="328" alt="image" src="https://github.com/user-attachments/assets/23bc2483-15ec-4898-be93-8489e9682325" />
