### PR TITLE
fix: type hint when whatchfiles library is not installed

### DIFF
--- a/taskiq/cli/worker/process_manager.py
+++ b/taskiq/cli/worker/process_manager.py
@@ -159,7 +159,7 @@ class ProcessManager:
         self,
         args: WorkerArgs,
         worker_function: Callable[[WorkerArgs], None],
-        observer: Observer | None = None,  # type: ignore[valid-type]
+        observer: "Observer | None" = None,  # type: ignore[valid-type]
     ) -> None:
         self.worker_function = worker_function
         self.action_queue: Queue[ProcessActionBase] = Queue(-1)


### PR DESCRIPTION
When `taskiq scheduler --help` called without `watchdog` installed, this issue occur:

```
Traceback (most recent call last):
  File "/home/s3rius/projects/github/taskiq/taskiq/.venv/bin/taskiq", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/s3rius/projects/github/taskiq/taskiq/taskiq/__main__.py", line 47, in main
    cmd_class = entrypoint.load()
  File "/home/s3rius/.local/share/uv/python/cpython-3.13.1-linux-x86_64-gnu/lib/python3.13/importlib/metadata/__init__.py", line 179, in load
    module = import_module(match.group('module'))
  File "/home/s3rius/.local/share/uv/python/cpython-3.13.1-linux-x86_64-gnu/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/s3rius/projects/github/taskiq/taskiq/taskiq/cli/worker/cmd.py", line 6, in <module>
    from taskiq.cli.worker.run import run_worker
  File "/home/s3rius/projects/github/taskiq/taskiq/taskiq/cli/worker/run.py", line 15, in <module>
    from taskiq.cli.worker.process_manager import ProcessManager
  File "/home/s3rius/projects/github/taskiq/taskiq/taskiq/cli/worker/process_manager.py", line 149, in <module>
    class ProcessManager:
    ...<139 lines>...
                        )
  File "/home/s3rius/projects/github/taskiq/taskiq/taskiq/cli/worker/process_manager.py", line 162, in ProcessManager
    observer: Observer | None = None,  # type: ignore[valid-type]
              ~~~~~~~~~^~~~~~
TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType'
```

This pull request fixes it by using old-style type hint `Optional` 