### PR TITLE
feat: add ability to specify ensure_ascii for JSONSerializer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ line-length = 88
 	"S311",   # Standard pseudo-random generators are not suitable for security/cryptographic purposes
 	"D101",   # Missing docstring in public class
 	"D102",   # Missing docstring in public method
+	"PLR2004",  # Magic value
 ]
 "docs/examples/*" = [
 	"D103",  # Missing docstring in public function

--- a/taskiq/serializers/json_serializer.py
+++ b/taskiq/serializers/json_serializer.py
@@ -8,8 +8,13 @@ from taskiq.abc.serializer import TaskiqSerializer
 class JSONSerializer(TaskiqSerializer):
     """Default taskiq serializer."""
 
-    def __init__(self, default: Callable[..., None] | None = None) -> None:
+    def __init__(
+        self,
+        default: Callable[..., None] | None = None,
+        ensure_ascii: bool = True,
+    ) -> None:
         self.default = default
+        self.ensure_ascii = ensure_ascii
 
     def dumpb(self, value: Any) -> bytes:
         """
@@ -21,6 +26,7 @@ class JSONSerializer(TaskiqSerializer):
         return dumps(
             value,
             default=self.default,
+            ensure_ascii=self.ensure_ascii,
         ).encode()
 
     def loadb(self, value: bytes) -> Any:

--- a/tests/serializers/test_json_serializer.py
+++ b/tests/serializers/test_json_serializer.py
@@ -1,19 +1,33 @@
+import pytest
+
 from taskiq.serializers.json_serializer import JSONSerializer
 
 
-async def test_json_dumpb() -> None:
+def test_json_dumpb() -> None:
     serizalizer = JSONSerializer()
-    assert serizalizer.dumpb(None) == b"null"  # noqa: PLR2004
-    assert serizalizer.dumpb(1) == b"1"  # noqa: PLR2004
-    assert serizalizer.dumpb("a") == b'"a"'  # noqa: PLR2004
-    assert serizalizer.dumpb(["a"]) == b'["a"]'  # noqa: PLR2004
-    assert serizalizer.dumpb({"a": "b"}) == b'{"a": "b"}'  # noqa: PLR2004
+    assert serizalizer.dumpb(None) == b"null"
+    assert serizalizer.dumpb(1) == b"1"
+    assert serizalizer.dumpb("a") == b'"a"'
+    assert serizalizer.dumpb(["a"]) == b'["a"]'
+    assert serizalizer.dumpb({"a": "b"}) == b'{"a": "b"}'
 
 
-async def test_json_loadb() -> None:
+def test_json_loadb() -> None:
     serizalizer = JSONSerializer()
     assert serizalizer.loadb(b"null") is None
     assert serizalizer.loadb(b"1") == 1
     assert serizalizer.loadb(b'"a"') == "a"
     assert serizalizer.loadb(b'["a"]') == ["a"]
     assert serizalizer.loadb(b'{"a": "b"}') == {"a": "b"}
+
+
+@pytest.mark.parametrize(
+    ("ensure_ascii", "result"),
+    [
+        (True, b'"\\u043f\\u0440\\u0438\\u0432\\u0435\\u0442"'),
+        (False, b'"\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"'),
+    ],
+)
+def test_json_dumpb_with_ensure_ascii(ensure_ascii: bool, result: bytes) -> None:
+    serizalizer = JSONSerializer(ensure_ascii=ensure_ascii)
+    assert serizalizer.dumpb("привет") == result


### PR DESCRIPTION
Case is simple: I want to store russian symbols in database in human readable format