### PR TITLE
Fix: Handle missing worker processes on shutdown

### DIFF
--- a/taskiq/cli/worker/process_manager.py
+++ b/taskiq/cli/worker/process_manager.py
@@ -214,6 +214,23 @@ class ProcessManager:
         for worker, event in zip(self.workers, events, strict=True):
             _wait_for_worker_startup(worker, event)
 
+    def _shutdown_workers(self) -> None:
+        for worker in self.workers:
+            if worker.pid:
+                try:
+                    os.kill(worker.pid, signal.SIGINT)
+                    logger.info(
+                        "Stopped process %s with pid %s",
+                        worker.name,
+                        worker.pid,
+                    )
+                except ProcessLookupError:
+                    logger.info(
+                        "Process %s (pid %s) already terminated",
+                        worker.name,
+                        worker.pid,
+                    )
+
     def start(self) -> int | None:  # noqa: C901
         """
         Start managing child processes.
@@ -273,21 +290,7 @@ class ProcessManager:
                     reloaded_workers.add(action.worker_num)
                 elif isinstance(action, ShutdownAction):
                     logger.debug("Process manager closed, killing workers.")
-                    for worker in self.workers:
-                        if worker.pid:
-                            try:
-                                os.kill(worker.pid, signal.SIGINT)
-                                logger.info(
-                                    "Stopped process %s with pid %s",
-                                    worker.name,
-                                    worker.pid,
-                                )
-                            except ProcessLookupError:
-                                logger.info(
-                                    "Process %s (pid %s) already terminated",
-                                    worker.name,
-                                    worker.pid,
-                                )
+                    self._shutdown_workers()
                     return None
 
             for worker_num, worker in enumerate(self.workers):


### PR DESCRIPTION
Added exception handling for ProcessLookupError when killing worker processes during shutdown. Now logs if a process is already terminated, improving robustness and clarity in process management.