### PR TITLE
Fixed reload-loop.

### DIFF
--- a/taskiq/cli/watcher.py
+++ b/taskiq/cli/watcher.py
@@ -37,10 +37,12 @@ class FileWatcher:  # pragma: no cover
         """
         if event.is_directory:
             return
-        if event.event_type in {"opened", "closed"}:
+        if event.event_type in {"opened", "closed", "closed_no_write"}:
             return
+
         if ".git" in event.src_path:
             return
+
         try:
             if self.gitignore and self.gitignore(event.src_path):
                 return


### PR DESCRIPTION
I wanted to make filewatching more precise to reduce number of files we are watching. But using modules for that is not an option. Unless we implement restart functionality in processes themselves. Which is much harder and seems like an overengineered solutions. 

So instead I just added more filters to avoid reload loops. 