### PR TITLE
Add support for jitter so that we can ensure evenly distributed tasks don't cause all workers to restart at same time

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -150,7 +150,7 @@ The number of signals before a hard kill can be configured with the `--hardkill-
 * `--shutdown-timeout` - maximum amount of time for graceful broker's shutdown in seconds (default 5).
 * `--wait-tasks-timeout` - if cannot read new messages from the broker or maximum number of tasks is reached, worker will wait for all current tasks to finish. This parameter sets the maximum amount of time to wait until shutdown.
 * `--hardkill-count` - Number of termination signals to the main process before performing a hardkill.
-* 
+
 ## Scheduler
 
 Scheduler is used to schedule tasks as described in [Scheduling tasks](./scheduling-tasks.md) section.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -138,6 +138,7 @@ The number of signals before a hard kill can be configured with the `--hardkill-
 * `--log-level` is used to set a log level (default `INFO`).
 * `--log-format` is used to set a log format (default `%(asctime)s][%(name)s][%(levelname)-7s][%(processName)s] %(message)s`).
 * `--max-async-tasks` - maximum number of simultaneously running async tasks.
+* `--max-async-tasks-jitter` – Randomly varies the max async task limit between --max-async-tasks and a jittered value, helping prevent simultaneous worker restarts.
 * `--max-prefetch` - number of tasks to be prefetched before execution. (Useful for systems with high message rates, but brokers should support acknowledgements).
 * `--max-threadpool-threads` - number of threads for sync function execution.
 * `--no-propagate-errors` - if this parameter is enabled, exceptions won't be thrown in generator dependencies.
@@ -149,7 +150,7 @@ The number of signals before a hard kill can be configured with the `--hardkill-
 * `--shutdown-timeout` - maximum amount of time for graceful broker's shutdown in seconds (default 5).
 * `--wait-tasks-timeout` - if cannot read new messages from the broker or maximum number of tasks is reached, worker will wait for all current tasks to finish. This parameter sets the maximum amount of time to wait until shutdown.
 * `--hardkill-count` - Number of termination signals to the main process before performing a hardkill.
-
+* 
 ## Scheduler
 
 Scheduler is used to schedule tasks as described in [Scheduling tasks](./scheduling-tasks.md) section.

--- a/taskiq/api/receiver.py
+++ b/taskiq/api/receiver.py
@@ -15,6 +15,7 @@ async def run_receiver_task(
     sync_workers: int | None = None,
     validate_params: bool = True,
     max_async_tasks: int = 100,
+    max_async_tasks_jitter: int = 0,
     max_prefetch: int = 0,
     propagate_exceptions: bool = True,
     run_startup: bool = False,
@@ -43,6 +44,7 @@ async def run_receiver_task(
         or processes in processpool that runs sync tasks.
     :param validate_params: whether to validate params or not.
     :param max_async_tasks: maximum number of simultaneous async tasks.
+    :param max_async_tasks_jitter: random jitter to add to max_async_tasks.
     :param max_prefetch: maximum number of tasks to prefetch.
     :param propagate_exceptions: whether to propagate exceptions in generators or not.
     :param run_startup: whether to run startup function or not.
@@ -79,6 +81,7 @@ async def run_receiver_task(
                     run_startup=run_startup,
                     validate_params=validate_params,
                     max_async_tasks=max_async_tasks,
+                    max_async_tasks_jitter=max_async_tasks_jitter,
                     max_prefetch=max_prefetch,
                     propagate_exceptions=propagate_exceptions,
                     on_exit=on_exit,

--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -127,6 +127,7 @@ class InMemoryBroker(AsyncBroker):
         max_stored_results: int = 100,
         cast_types: bool = True,
         max_async_tasks: int = 30,
+        max_async_tasks_jitter: int = 0,
         propagate_exceptions: bool = True,
         await_inplace: bool = False,
     ) -> None:
@@ -140,6 +141,7 @@ class InMemoryBroker(AsyncBroker):
             executor=self.executor,
             validate_params=cast_types,
             max_async_tasks=max_async_tasks,
+            max_async_tasks_jitter=max_async_tasks_jitter,
             propagate_exceptions=propagate_exceptions,
         )
         self.await_inplace = await_inplace

--- a/taskiq/cli/worker/args.py
+++ b/taskiq/cli/worker/args.py
@@ -44,6 +44,7 @@ class WorkerArgs:
     reload_dirs: list[str] = field(default_factory=list)
     no_gitignore: bool = False
     max_async_tasks: int = 100
+    max_async_tasks_jitter: int = 0
     receiver: str = "taskiq.receiver:Receiver"
     receiver_arg: list[tuple[str, str]] = field(default_factory=list)
     max_prefetch: int = 0
@@ -209,6 +210,14 @@ class WorkerArgs:
             dest="max_async_tasks",
             default=100,
             help="Maximum simultaneous async tasks per worker process. ",
+        )
+        parser.add_argument(
+            "--max-async-tasks-jitter",
+            type=int,
+            dest="max_async_tasks_jitter",
+            default=0,
+            help="Add random jitter (0 to this value) to max-async-tasks to prevent "
+            "all workers from closing at the same time. ",
         )
         parser.add_argument(
             "--max-prefetch",

--- a/taskiq/cli/worker/run.py
+++ b/taskiq/cli/worker/run.py
@@ -165,6 +165,7 @@ def start_listen(args: WorkerArgs) -> None:
                 executor=pool,
                 validate_params=not args.no_parse,
                 max_async_tasks=args.max_async_tasks,
+                max_async_tasks_jitter=args.max_async_tasks_jitter,
                 max_prefetch=args.max_prefetch,
                 propagate_exceptions=not args.no_propagate_errors,
                 ack_type=args.ack_type,

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -85,7 +85,11 @@ class Receiver:
             # Apply jitter to prevent all workers from hitting the limit simultaneously
             actual_limit = max_async_tasks
             if max_async_tasks_jitter > 0:
-                actual_limit = max_async_tasks + random.randint(0, max_async_tasks_jitter)
+                # Using standard random for load distribution, not cryptography
+                actual_limit = max_async_tasks + random.randint(  # noqa: S311
+                    0,
+                    max_async_tasks_jitter,
+                )
             self.sem = asyncio.Semaphore(actual_limit)
         else:
             logger.warning(

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import functools
 import inspect
+import random
 import sys
 from collections.abc import Callable
 from concurrent.futures import Executor, ProcessPoolExecutor
@@ -55,6 +56,7 @@ class Receiver:
         executor: Executor | None = None,
         validate_params: bool = True,
         max_async_tasks: "int | None" = None,
+        max_async_tasks_jitter: int = 0,
         max_prefetch: int = 0,
         propagate_exceptions: bool = True,
         run_startup: bool = True,
@@ -80,7 +82,11 @@ class Receiver:
             self._prepare_task(task.task_name, task.original_func)
         self.sem: asyncio.Semaphore | None = None
         if max_async_tasks is not None and max_async_tasks > 0:
-            self.sem = asyncio.Semaphore(max_async_tasks)
+            # Apply jitter to prevent all workers from hitting the limit simultaneously
+            actual_limit = max_async_tasks
+            if max_async_tasks_jitter > 0:
+                actual_limit = max_async_tasks + random.randint(0, max_async_tasks_jitter)
+            self.sem = asyncio.Semaphore(actual_limit)
         else:
             logger.warning(
                 "Setting unlimited number of async tasks "


### PR DESCRIPTION
## Summary

This PR adds jitter support to the `max_async_tasks` parameter to prevent synchronized worker restarts. When multiple workers are configured with the same `max_async_tasks` limit and receive evenly distributed tasks, they tend to hit their limits simultaneously, causing cascading restarts that can impact system stability.

## Changes

- **New `max_async_tasks_jitter` parameter**: Added across the receiver, broker, and CLI interfaces to configure randomized jitter
- **Randomized semaphore limits**: The receiver now applies a random value (0 to jitter value) to the base `max_async_tasks` limit when creating the semaphore
- **CLI argument**: Added `--max-async-tasks-jitter` flag to worker command for runtime configuration

## Technical Details

The implementation distributes worker restart times by randomizing each worker's actual task limit. For example, with `max_async_tasks=100` and `max_async_tasks_jitter=10`, workers will have limits ranging from 100 to 110. This prevents the thundering herd problem where synchronized restarts cause all workers to compete for the same resources simultaneously, leading to more graceful degradation under load.