### PR TITLE
Add MIT License classifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 	"Intended Audience :: Developers",
 	"Topic :: System :: Networking",
 	"Development Status :: 3 - Alpha",
+	    "License :: OSI Approved :: MIT License",
 ]
 keywords = ["taskiq", "tasks", "distributed", "async"]
 requires-python = ">=3.10,<4"


### PR DESCRIPTION

This PR adds the missing MIT License classifier to the classifiers list in pyproject.toml. This allows license checkers like licensecheck to properly detect the project's MIT license instead of marking it as UNKNOWN.