### PR TITLE
Added Fastapi Lifespan to docs 

### DIFF
--- a/docs/framework_integrations/taskiq-with-fastapi.md
+++ b/docs/framework_integrations/taskiq-with-fastapi.md
@@ -19,6 +19,7 @@ import taskiq_fastapi
 broker = ZeroMQBroker()
 
 taskiq_fastapi.init(broker, "my_package.application:app")
+
 ```
 
 There are two rules to make everything work as you expect:
@@ -42,6 +43,7 @@ from typing import Any
 
 def get_redis_pool(request: Request) -> Any:
     return request.app.state.redis_pool
+
 ```
 
 To make it resolvable in taskiq, people should mark default fastapi dependencies (such as `Request` and `HTTPConnection`) with `TaskiqDepends`. Like this:
@@ -59,6 +61,7 @@ from taskiq import TaskiqDepends
 
 async def get_redis_pool(request: Annotated[Request, TaskiqDepends()]):
     return request.app.state.redis_pool
+
 ```
 
 @tab default values
@@ -70,6 +73,7 @@ from taskiq import TaskiqDepends
 
 async def get_redis_pool(request: Request = TaskiqDepends()):
     return request.app.state.redis_pool
+
 ```
 
 :::
@@ -111,7 +115,7 @@ app = FastAPI()
 
 
 @app.on_event("startup")
-asynchronous def app_startup():
+async def app_startup():
     if not broker.is_worker_process:
         await broker.startup()
 
@@ -120,6 +124,7 @@ asynchronous def app_startup():
 async def app_shutdown():
     if not broker.is_worker_process:
         await broker.shutdown()
+
 ```
 
 :::
@@ -137,6 +142,7 @@ Let's imagine that you have a fixture of your application. It returns a new fast
 @pytest.fixture
 def fastapi_app() -> FastAPI:
     return get_app()
+
 ```
 
 Right after this fixture, we define another one.
@@ -155,6 +161,7 @@ def init_taskiq_deps(fastapi_app: FastAPI):
     yield
 
     broker.custom_dependency_context = {}
+
 ```
 
 This fixture has autouse flag, which means it would run on every test automatically.


### PR DESCRIPTION
This pull request updates the documentation for integrating Taskiq with FastAPI, focusing on how to properly manage broker startup and shutdown. The main improvement is the addition of a recommended approach using FastAPI's `lifespan` event, while also marking the older `on_event` method as deprecated.

Broker lifecycle management documentation:

* Added a new "Lifespan (Recommended)" tab with example code showing how to use FastAPI's `lifespan` event for broker startup and shutdown, ensuring proper resource management.
* Marked the `on_event` approach as deprecated and organized both methods into a tabbed interface for clarity. [[1]](diffhunk://#diff-6e06bb0b86eb0929ecea0a577c256bec70f0f1680ed8aa87210fd27e6ed0f651R84-R109) [[2]](diffhunk://#diff-6e06bb0b86eb0929ecea0a577c256bec70f0f1680ed8aa87210fd27e6ed0f651R130-R131)