### PR TITLE
Fix .gitignore search in FileWatcher

### DIFF
--- a/taskiq/cli/watcher.py
+++ b/taskiq/cli/watcher.py
@@ -21,9 +21,17 @@ class FileWatcher:  # pragma: no cover
     ) -> None:
         self.callback = callback
         self.gitignore = None
-        gpath = path / ".gitignore"
-        if use_gitignore and gpath.exists():
-            self.gitignore = parse_gitignore(gpath)
+        project_root = Path().resolve()
+        path = path.resolve()
+
+        if use_gitignore:
+            while path != project_root.parent:
+                gpath = path / ".gitignore"
+                if gpath.exists():
+                    self.gitignore = parse_gitignore(gpath)
+                    break
+                path = path.parent
+
         self.callback_kwargs = callback_kwargs
 
     def dispatch(self, event: FileSystemEvent) -> None:


### PR DESCRIPTION
### Summary

When using `--reload-dir`, the `FileWatcher` can't find `.gitignore` file since it only looks in the watched directory, not in the project root.

### Changes

- `FileWatcher` now start searching for `.gitignore` in `--reload-dir` directory and goes upper until it reaches project root.

Fixes #591 issue.
I suppose it was broken first time [here](https://github.com/taskiq-python/taskiq/commit/26485ff2ae5067b0d82f40c0dcfc60240f0fda7b).
