### PR TITLE
docs: fix typo at max_retries explanation

### DIFF
--- a/docs/available-components/middlewares.md
+++ b/docs/available-components/middlewares.md
@@ -32,7 +32,7 @@ async def test():
 
 ```
 
-`retry_on_error` enables retries for a task. `max_retries` is the maximum number of times,.
+`retry_on_error` enables retries for a task. `max_retries` is the maximum number of retry attempts.
 
 ## Smart retry middleware
 


### PR DESCRIPTION
I fixed small typo at max_retries explanation message in middleware docs.