### PR TITLE
Get rid of izulu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
 	"taskiq_dependencies>=1.3.1,<2",
 	"anyio>=4",
 	"packaging>=19",
-	"izulu==0.50.0",
 	"aiohttp>=3",
 ]
 

--- a/taskiq/error.py
+++ b/taskiq/error.py
@@ -1,8 +1,20 @@
 """Minimal exception templating used by taskiq exceptions."""
 
+import sys
 from string import Formatter
 
+if sys.version_info >= (3, 11):
+    from typing import dataclass_transform
+else:
+    from typing_extensions import dataclass_transform
 
+
+@dataclass_transform(
+    eq_default=False,
+    order_default=False,
+    kw_only_default=True,
+    frozen_default=False,
+)
 class Error(Exception):
     """Base templated exception compatible with taskiq needs."""
 

--- a/taskiq/error.py
+++ b/taskiq/error.py
@@ -1,0 +1,70 @@
+"""Minimal exception templating used by taskiq exceptions."""
+
+from string import Formatter
+
+
+class Error(Exception):
+    """Base templated exception compatible with taskiq needs."""
+
+    __template__ = "Exception occurred"
+
+    @classmethod
+    def _collect_annotations(cls) -> dict[str, object]:
+        """Collect all annotated fields from the class hierarchy."""
+        annotations: dict[str, object] = {}
+        for class_ in reversed(cls.__mro__):
+            annotations.update(getattr(class_, "__annotations__", {}))
+        return annotations
+
+    @classmethod
+    def _format_fields(cls, names: set[str]) -> str:
+        """Format field names in a deterministic error message."""
+        return ", ".join(f"'{name}'" for name in sorted(names))
+
+    @classmethod
+    def _template_fields(cls, template: str) -> set[str]:
+        """Extract plain field names used in a format template."""
+        fields: set[str] = set()
+        for _, field_name, _, _ in Formatter().parse(template):
+            if not field_name:
+                continue
+            field = field_name.split(".", maxsplit=1)[0].split("[", maxsplit=1)[0]
+            fields.add(field)
+        return fields
+
+    def __init__(self, **kwargs: object) -> None:
+        annotations = self._collect_annotations()
+        undeclared = set(kwargs) - set(annotations)
+        if undeclared:
+            raise TypeError(f"Undeclared arguments: {self._format_fields(undeclared)}")
+
+        missing = {
+            field
+            for field in annotations
+            if field not in kwargs and not hasattr(type(self), field)
+        }
+        if missing:
+            raise TypeError(f"Missing arguments: {self._format_fields(missing)}")
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+        template = getattr(type(self), "__template__", self.__template__)
+        missing_annotations = self._template_fields(template) - set(annotations)
+        if missing_annotations:
+            raise ValueError(
+                f"Fields must be annotated: {self._format_fields(missing_annotations)}",
+            )
+
+        payload = {field: getattr(self, field) for field in annotations}
+        super().__init__(template.format(**payload))
+
+    def __repr__(self) -> str:
+        """Represent exception with all declared fields."""
+        annotations = self._collect_annotations()
+        module = type(self).__module__
+        qualname = type(self).__qualname__
+        if not annotations:
+            return f"{module}.{qualname}()"
+        args = ", ".join(f"{field}={getattr(self, field)!r}" for field in annotations)
+        return f"{module}.{qualname}({args})"

--- a/taskiq/exceptions.py
+++ b/taskiq/exceptions.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from izulu import root
+from taskiq.error import Error
 
 
-class TaskiqError(root.Error):
+class TaskiqError(Error):
     """Base exception for all errors."""
 
     __template__ = "Exception occurred"

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -51,12 +51,12 @@ def test_template_with_required_value() -> None:
 
 def test_missing_argument_raises_type_error() -> None:
     with pytest.raises(TypeError, match="Missing arguments: 'value'"):
-        ValueTemplateError()
+        ValueTemplateError()  # type: ignore[call-arg]
 
 
 def test_undeclared_argument_raises_type_error() -> None:
     with pytest.raises(TypeError, match="Undeclared arguments: 'extra'"):
-        ValueTemplateError(value=1, extra=2)
+        ValueTemplateError(value=1, extra=2)  # type: ignore[call-arg]
 
 
 def test_default_value_is_used_without_kwargs() -> None:

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,88 @@
+import pytest
+
+from taskiq.error import Error
+from taskiq.exceptions import SecurityError, TaskiqResultTimeoutError
+
+
+class SimpleError(Error):
+    __template__ = "simple"
+
+
+class ValueTemplateError(Error):
+    __template__ = "value={value}"
+    value: int
+
+
+class DefaultValueTemplateError(Error):
+    __template__ = "value={value}"
+    value: int = 10
+
+
+class BaseError(Error):
+    __template__ = "base={base}, child={child}"
+    base: int = 1
+
+
+class ChildError(BaseError):
+    child: str
+
+
+class MissingAnnotationError(Error):
+    __template__ = "value={value}"
+
+
+class IndexedTemplateError(Error):
+    __template__ = "{payload[key]}"
+    payload: dict[str, str]
+
+
+def test_simple_error_message_and_repr() -> None:
+    error = SimpleError()
+    assert str(error) == "simple"
+    assert error.args == ("simple",)
+    assert repr(error).endswith(".SimpleError()")
+
+
+def test_template_with_required_value() -> None:
+    error = ValueTemplateError(value=3)
+    assert str(error) == "value=3"
+    assert repr(error).endswith(".ValueTemplateError(value=3)")
+
+
+def test_missing_argument_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="Missing arguments: 'value'"):
+        ValueTemplateError()
+
+
+def test_undeclared_argument_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="Undeclared arguments: 'extra'"):
+        ValueTemplateError(value=1, extra=2)
+
+
+def test_default_value_is_used_without_kwargs() -> None:
+    error = DefaultValueTemplateError()
+    assert str(error) == "value=10"
+    assert repr(error).endswith(".DefaultValueTemplateError(value=10)")
+
+
+def test_annotations_are_collected_from_inheritance() -> None:
+    error = ChildError(child="ok")
+    assert str(error) == "base=1, child=ok"
+    assert repr(error).endswith(".ChildError(base=1, child='ok')")
+
+
+def test_template_fields_must_be_annotated() -> None:
+    with pytest.raises(ValueError, match="Fields must be annotated: 'value'"):
+        MissingAnnotationError()
+
+
+def test_indexed_template_field_does_not_require_extra_annotation() -> None:
+    error = IndexedTemplateError(payload={"key": "value"})
+    assert str(error) == "value"
+
+
+def test_taskiq_exceptions_use_error_base_correctly() -> None:
+    timeout_error = TaskiqResultTimeoutError(timeout=1.5)
+    security_error = SecurityError(description="boom")
+    assert str(timeout_error) == "Waiting for task results has timed out, timeout=1.5"
+    assert str(security_error) == "Security exception occurred: boom"

--- a/tests/test_exceptions_flow.py
+++ b/tests/test_exceptions_flow.py
@@ -1,0 +1,66 @@
+import re
+
+import pytest
+
+from taskiq import InMemoryBroker
+from taskiq.brokers.shared_broker import AsyncSharedBroker
+from taskiq.exceptions import (
+    SharedBrokerListenError,
+    SharedBrokerSendTaskError,
+    TaskBrokerMismatchError,
+    UnknownTaskError,
+)
+from taskiq.message import BrokerMessage
+
+
+def _broker_message(task_name: str) -> BrokerMessage:
+    return BrokerMessage(
+        task_id="task-id",
+        task_name=task_name,
+        message=b"{}",
+        labels={},
+    )
+
+
+async def test_inmemory_broker_raises_unknown_task_error() -> None:
+    broker = InMemoryBroker()
+
+    with pytest.raises(
+        UnknownTaskError,
+        match=re.escape(
+            "Cannot send unknown task to the queue, task name - missing.task",
+        ),
+    ):
+        await broker.kick(_broker_message("missing.task"))
+
+
+async def test_shared_broker_raises_send_task_error() -> None:
+    broker = AsyncSharedBroker()
+
+    with pytest.raises(
+        SharedBrokerSendTaskError,
+        match="You cannot use kiq directly on shared task",
+    ):
+        await broker.kick(_broker_message("any.task"))
+
+
+async def test_shared_broker_raises_listen_error() -> None:
+    broker = AsyncSharedBroker()
+
+    with pytest.raises(SharedBrokerListenError, match="Shared broker cannot listen"):
+        await broker.listen()
+
+
+def test_registering_task_in_another_broker_raises_mismatch_error() -> None:
+    first_broker = InMemoryBroker()
+    second_broker = InMemoryBroker()
+
+    @first_broker.task(task_name="test.task")
+    async def test_task() -> None:
+        return None
+
+    with pytest.raises(
+        TaskBrokerMismatchError,
+        match="Task already has a different broker",
+    ):
+        second_broker._register_task(test_task.task_name, test_task)

--- a/uv.lock
+++ b/uv.lock
@@ -754,15 +754,6 @@ wheels = [
 ]
 
 [[package]]
-name = "izulu"
-version = "0.50.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/58/6d6335c78b7ade54d8a6c6dbaa589e5c21b3fd916341d5a16f774c72652a/izulu-0.50.0.tar.gz", hash = "sha256:cc8e252d5e8560c70b95380295008eeb0786f7b745a405a40d3556ab3252d5f5", size = 48558, upload-time = "2025-03-24T15:52:21.51Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/9f/bf9d33546bbb6e5e80ebafe46f90b7d8b4a77410b7b05160b0ca8978c15a/izulu-0.50.0-py3-none-any.whl", hash = "sha256:4e9ae2508844e7c5f62c468a8b9e2deba2f60325ef63f01e65b39fd9a6b3fab4", size = 18095, upload-time = "2025-03-24T15:52:19.667Z" },
-]
-
-[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1820,7 +1811,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
-    { name = "izulu" },
     { name = "packaging" },
     { name = "pycron" },
     { name = "pydantic" },
@@ -1881,7 +1871,6 @@ requires-dist = [
     { name = "anyio", specifier = ">=4" },
     { name = "cbor2", marker = "extra == 'cbor'", specifier = ">=5" },
     { name = "gitignore-parser", marker = "extra == 'reload'", specifier = ">=0" },
-    { name = "izulu", specifier = "==0.50.0" },
     { name = "msgpack", marker = "extra == 'msgpack'", specifier = ">=1.0.7" },
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.38.0,<2.0.0" },
     { name = "opentelemetry-instrumentation", marker = "extra == 'opentelemetry'", specifier = ">=0.59b0,<1" },


### PR DESCRIPTION
idk why we need izulu here. It's a strange lib.

What concerns me:
- why we froze version 0.50.0 when there's already 0.75.0?
- why all latest releases of izulu are broken?
- why rely on a 3rd-party library that has exactly one maintainer?
- why [izulu claims](https://github.com/pyctrl/izulu/blob/f51c8f1f420094f2122a2e4ead2ac70f6bc0c5b6/pyproject.toml#L12) that it's MIT-licensed, but in the [license file](https://github.com/pyctrl/izulu/blob/main/LICENSE) it has custom license?

taskiq doesn't even utilize so much from the izulu library.

Let's get rid of it. It's just about 70 lines of code.

Here's my MIT-licensed source code that can be just copy-pasted into the project. Remember the [left-pad](https://habr.com/ru/articles/280099/).

https://gist.github.com/mahenzon/5ac32267ebd6d29a44dd52bb94a9630c
