### PR TITLE
Fixed shared labels.

### DIFF
--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -1,5 +1,6 @@
 import sys
 from collections.abc import Callable, Coroutine
+from copy import copy
 from datetime import datetime, timedelta
 from types import CoroutineType
 from typing import (
@@ -225,7 +226,7 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
         return AsyncKicker(
             task_name=self.task_name,
             broker=self.broker,
-            labels=self.labels,
+            labels=copy(self.labels),
             return_type=self.return_type,
         )
 

--- a/tests/abc/test_broker.py
+++ b/tests/abc/test_broker.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncGenerator
+from copy import copy
 
 from taskiq.abc.broker import AsyncBroker
 from taskiq.decor import AsyncTaskiqDecoratedTask
@@ -61,3 +62,17 @@ def test_decorator_with_labels_success() -> None:
         "label1": 1,
         "label2": 2,
     }
+
+
+def test_kicker_labels_modification() -> None:
+    """Test that using kicker.with_labels doesn't modify task's labels globally."""
+    broker = _TestBroker()
+
+    @broker.task(test_lb="one")
+    async def test_task() -> None: ...
+
+    old_labels = copy(test_task.labels)
+    test_kicker = test_task.kicker().with_labels(another_label="test")
+    assert "another_label" in test_kicker.labels
+
+    assert test_task.labels == old_labels


### PR DESCRIPTION
This issue was causing task labels to be updated, when it should have updated labels only for one kiq. 