### PR TITLE
Add worker resource and queue metrics to OTel instrumentation

### DIFF
--- a/taskiq/middlewares/opentelemetry_middleware.py
+++ b/taskiq/middlewares/opentelemetry_middleware.py
@@ -2,7 +2,8 @@ import logging
 from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from importlib.metadata import version
-from typing import Any, TypeVar
+from typing import Any, Generator, TypeVar
+import psutil
 
 from packaging.version import Version, parse
 
@@ -17,7 +18,7 @@ except ImportError as exc:
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
-from opentelemetry.metrics import Meter, MeterProvider, get_meter
+from opentelemetry.metrics import Meter, MeterProvider, Observation, get_meter
 from opentelemetry.propagate import extract, inject
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, Tracer, TracerProvider
@@ -205,6 +206,30 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
             unit="s",
             description="Time the tasks waited before executing",
         )
+        # current metrics to watch for in workers: CPU and memory utilization
+        self._process = psutil.Process()
+        # 6- CPU utilization
+        self.worker_cpu_utilization = self._meter.create_observable_gauge(
+            "worker_cpu_utilization",
+            callbacks=[self._observe_cpu],
+            unit="%",
+            description="Worker CPU utilization percentage. Only for worker processes",
+        )
+        # 7- Memory utilization
+        self.worker_memory_utilization = self._meter.create_observable_gauge(
+            "worker_memory_utilization",
+            callbacks=[self._observe_memory],
+            unit="By",
+            description="Worker memory utilization in bytes. Only for worker processes",
+        )
+
+    def _observe_memory(self, _options: Any) -> Generator[Observation, None, None]:
+        if self.broker and self.broker.is_worker_process:
+            yield Observation(self._process.memory_info().rss)
+
+    def _observe_cpu(self, _options: Any) -> Generator[Observation, None, None]:
+        if self.broker and self.broker.is_worker_process:
+            yield Observation(self._process.cpu_percent())
 
     def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
         """

--- a/taskiq/middlewares/opentelemetry_middleware.py
+++ b/taskiq/middlewares/opentelemetry_middleware.py
@@ -1,5 +1,6 @@
 import logging
 from contextlib import AbstractContextManager
+from datetime import datetime, timezone
 from importlib.metadata import version
 from typing import Any, TypeVar
 
@@ -58,6 +59,9 @@ _TASK_EXECUTE = "execute"
 
 _TASK_RETRY_REASON_KEY = "taskiq.retry.reason"
 _TASK_NAME_KEY = "taskiq.task_name"
+
+_TASK_QUEUE_TIME_KEY = "_taskiq_queue_time"
+_TASK_RECEIVED_TIME_KEY = "_taskiq_broker_receive_time"
 
 
 def set_attributes_from_context(span: Span, context: dict[str, Any]) -> None:
@@ -170,6 +174,37 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
             if meter is None
             else meter
         )
+        # Create metrics
+        # 1- Number of tasks sent. Producer (Counter)
+        self.n_tasks_sent_counter = self._meter.create_counter(
+            name="tasks_sent",
+            unit="1",
+            description="Number of tasks sent from the producer side",
+        )
+        # 2- Number of errors by task name. consumer (Counter)
+        self.n_errors_counter = self._meter.create_counter(
+            name="task_errors",
+            unit="1",
+            description="Number of errors raised",
+        )
+        # 3- Number of task successes. consumer (Counter)
+        self.n_success_counter = self._meter.create_counter(
+            name="task_success",
+            unit="1",
+            description="Number of tasks completed successfully",
+        )
+        # 4- Task execution time. consumer (Histogram)
+        self.execution_time_hist = self._meter.create_histogram(
+            "task_execution_time",
+            unit="s",
+            description="Time to finish executing tasks",
+        )
+        # 5- Task wait time. both (Histogram)
+        self.task_wait_time = self._meter.create_histogram(
+            "task_wait_time",
+            unit="s",
+            description="Time the tasks waited before executing",
+        )
 
     def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
         """
@@ -193,7 +228,7 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
         activation.__enter__()
         attach_context(message, span, activation, None, is_publish=True)
         inject(message.labels)
-
+        message.labels[_TASK_QUEUE_TIME_KEY] = datetime.now(timezone.utc).timestamp()
         return message
 
     def post_send(self, message: TaskiqMessage) -> None:
@@ -214,6 +249,7 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
 
         activation.__exit__(None, None, None)
         detach_context(message, is_publish=True)
+        self.n_tasks_sent_counter.add(1, attributes={"task_name": message.task_name})
 
     def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
         """
@@ -236,6 +272,7 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
         activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()  # pylint: disable=E1101
         attach_context(message, span, activation, token)
+        message.labels[_TASK_RECEIVED_TIME_KEY] = datetime.now(timezone.utc).timestamp()
         return message
 
     def post_save(  # pylint: disable=R6301
@@ -313,3 +350,52 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
         }
         span.record_exception(exception)
         span.set_status(Status(**status_kwargs))  # type: ignore[arg-type]
+
+    def post_execute(
+        self,
+        message: "TaskiqMessage",
+        result: "TaskiqResult[Any]",
+    ) -> None:
+        """
+        This function tracks number of errors and success executions.
+
+        :param message: received message.
+        :param result: result of the execution.
+        """
+        if result.is_err:
+            retry_on_error = message.labels.get("retry_on_error")
+            if isinstance(retry_on_error, str):
+                retry_on_error = retry_on_error.lower() == "true"
+
+            if retry_on_error is None:
+                retry_on_error = False
+
+            if retry_on_error:
+                # Add retry reason metadata to span
+                self.n_errors_counter.add(
+                    1,
+                    attributes={"retry_error": True, "task_name": message.task_name},
+                )
+            else:
+                self.n_errors_counter.add(
+                    1,
+                    attributes={"retry_error": False, "task_name": message.task_name},
+                )
+        else:
+            self.n_success_counter.add(
+                1,
+                attributes={"task_name": message.task_name},
+            )
+        self.execution_time_hist.record(
+            result.execution_time,
+            attributes={
+                "task_name": message.task_name,
+            },
+        )
+        task_receive_time = message.labels.get(_TASK_RECEIVED_TIME_KEY)
+        task_send_time = message.labels.get(_TASK_QUEUE_TIME_KEY)
+        if task_receive_time is not None and task_send_time is not None:
+            self.task_wait_time.record(
+                amount=task_receive_time - task_send_time,
+                attributes={"task_name": message.task_name},
+            )

--- a/taskiq/middlewares/opentelemetry_middleware.py
+++ b/taskiq/middlewares/opentelemetry_middleware.py
@@ -1,10 +1,11 @@
 import logging
+from collections.abc import Generator
 from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from importlib.metadata import version
-from typing import Any, Generator, TypeVar
-import psutil
+from typing import Any, TypeVar
 
+import psutil
 from packaging.version import Version, parse
 
 try:
@@ -223,11 +224,24 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
             description="Worker memory utilization in bytes. Only for worker processes",
         )
 
-    def _observe_memory(self, _options: Any) -> Generator[Observation, None, None]:
+        # 8- Number of tasks executing
+        self.number_of_broker_active_tasks = self._meter.create_up_down_counter(
+            "worker_active_tasks",
+            unit="1",
+            description="Number of tasks currently executing in the worker.",
+        )
+        # 9- Number of tasks executing
+        self.number_of_broker_prefetched_tasks = self._meter.create_up_down_counter(
+            "worker_prefetched_tasks",
+            unit="1",
+            description="Number of tasks currently prefetched in the worker.",
+        )
+
+    def _observe_memory(self, options: Any) -> Generator[Observation, None, None]:
         if self.broker and self.broker.is_worker_process:
             yield Observation(self._process.memory_info().rss)
 
-    def _observe_cpu(self, _options: Any) -> Generator[Observation, None, None]:
+    def _observe_cpu(self, options: Any) -> Generator[Observation, None, None]:
         if self.broker and self.broker.is_worker_process:
             yield Observation(self._process.cpu_percent())
 
@@ -298,6 +312,10 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
         activation.__enter__()  # pylint: disable=E1101
         attach_context(message, span, activation, token)
         message.labels[_TASK_RECEIVED_TIME_KEY] = datetime.now(timezone.utc).timestamp()
+        self.number_of_broker_active_tasks.add(
+            1,
+            attributes={"task_name": message.task_name},
+        )
         return message
 
     def post_save(  # pylint: disable=R6301
@@ -424,3 +442,16 @@ class OpenTelemetryMiddleware(TaskiqMiddleware):
                 amount=task_receive_time - task_send_time,
                 attributes={"task_name": message.task_name},
             )
+
+        self.number_of_broker_active_tasks.add(
+            -1,
+            attributes={"task_name": message.task_name},
+        )
+
+    def on_prefetch_queue_add(self) -> None:
+        """This hook is called after task is added to the worker prefetch queue."""
+        self.number_of_broker_prefetched_tasks.add(1)
+
+    def on_prefetch_queue_remove(self) -> None:
+        """This hook is called after task is removed from the worker prefetch queue."""
+        self.number_of_broker_prefetched_tasks.add(-1)

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -415,6 +415,12 @@ class Receiver:
                 current_message = asyncio.create_task(iterator.__anext__())  # type: ignore
                 fetched_tasks += 1
                 await queue.put(message)
+                # Custom hooks for OTel and any future instrumentations
+                for middleware in reversed(self.broker.middlewares):
+                    if hasattr(middleware, "on_prefetch_queue_add"):
+                        await maybe_awaitable(
+                            middleware.on_prefetch_queue_add(),  # type: ignore
+                        )
             except (asyncio.CancelledError, StopAsyncIteration):
                 break
         # We don't want to fetch new messages if we are shutting down.
@@ -465,6 +471,13 @@ class Receiver:
                         await asyncio.wait(tasks, timeout=self.wait_tasks_timeout)
                         logger.info("No more tasks to wait for. Shutting down.")
                     break
+
+                # Custom hooks for OTel and any future instrumentations
+                for middleware in reversed(self.broker.middlewares):
+                    if hasattr(middleware, "on_prefetch_queue_remove"):
+                        await maybe_awaitable(
+                            middleware.on_prefetch_queue_remove(),  # type: ignore
+                        )
 
                 task = asyncio.create_task(
                     self.callback(message=message, raise_err=False),

--- a/tests/opentelemetry/taskiq_test_tasks.py
+++ b/tests/opentelemetry/taskiq_test_tasks.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 from opentelemetry import baggage
@@ -26,3 +27,8 @@ async def task_raises() -> None:
 @broker.task
 async def task_returns_baggage() -> Any:
     return dict(baggage.get_all())
+
+
+@broker.task
+async def task_does_processing(wait_time: float) -> None:
+    await asyncio.sleep(wait_time)

--- a/tests/opentelemetry/test_metrics.py
+++ b/tests/opentelemetry/test_metrics.py
@@ -1,0 +1,169 @@
+import asyncio
+from typing import Any
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.test.test_base import TestBase
+
+from taskiq.instrumentation import TaskiqInstrumentor
+
+from .taskiq_test_tasks import (
+    broker,
+    task_add,
+    task_does_processing,
+    task_raises,
+)
+
+
+class TestTaskiqOTelMetrics(TestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.reader = InMemoryMetricReader()
+        self.meter_provider = MeterProvider(metric_readers=[self.reader])
+        TaskiqInstrumentor().instrument_broker(
+            broker,
+            meter_provider=self.meter_provider,
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        TaskiqInstrumentor().uninstrument_broker(broker)
+
+    def _get_data_points(self, metric_name: str) -> list[Any]:
+        metrics = self.reader.get_metrics_data()
+        if metrics is None:
+            return []
+        return [
+            point
+            for rm in metrics.resource_metrics
+            for sm in rm.scope_metrics
+            for metric in sm.metrics
+            if metric.name == metric_name
+            for point in metric.data.data_points
+        ]
+
+    def test_metrics_exist(self) -> None:
+        async def test() -> None:
+            await task_add.kiq(1, 2)
+            await task_raises.kiq()
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        metrics = self.reader.get_metrics_data()
+        self.assertIsNotNone(metrics)
+        expected = {
+            "task_errors",
+            "tasks_sent",
+            "task_success",
+            "task_execution_time",
+            "task_wait_time",
+        }
+        found = {
+            metric.name
+            for rm in metrics.resource_metrics  # type: ignore[union-attr]
+            for sm in rm.scope_metrics
+            for metric in sm.metrics
+        }
+        self.assertSetEqual(found.intersection(expected), expected)
+
+    def test_success_counter(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_add.kiq(1, 2)
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("task_success")
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].value, 3)
+
+    def test_error_counter_no_retry(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_raises.kiq()
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("task_errors")
+        no_retry_points = [
+            p for p in points if p.attributes.get("retry_error") is False
+        ]
+        self.assertEqual(len(no_retry_points), 1)
+        self.assertEqual(no_retry_points[0].value, 3)
+
+    def test_error_counter_with_retry(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_raises.kicker().with_labels(retry_on_error="true").kiq()
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("task_errors")
+        retry_points = [p for p in points if p.attributes.get("retry_error") is True]
+        self.assertEqual(len(retry_points), 1)
+        self.assertEqual(retry_points[0].value, 3)
+
+    def test_execution_time_histogram(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_does_processing.kiq(0.01)
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("task_execution_time")
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].count, 3)
+        self.assertGreater(points[0].sum, 0)
+
+    def test_task_wait_time_histogram(self) -> None:
+        async def test() -> None:
+            await task_does_processing.kiq(0.01)
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("task_wait_time")
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].count, 1)
+        self.assertGreaterEqual(points[0].sum, 0)
+
+    def test_queue_time(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_add.kiq(1, 2)
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("task_wait_time")
+        # all 3 tasks share the same task_name so they aggregate into one data point
+        self.assertEqual(len(points), 1)
+        point = points[0]
+        # 3 tasks recorded
+        self.assertEqual(point.count, 3)
+        # queue time must be non-negative — a negative value means timestamps
+        # were not written/read correctly
+        self.assertGreaterEqual(point.sum, 0)
+        self.assertGreaterEqual(point.min, 0)
+        # task_name attribute must be present and correct
+        self.assertEqual(
+            point.attributes.get("task_name"),
+            "tests.opentelemetry.taskiq_test_tasks:task_add",
+        )
+
+    def test_tasks_sent_counter(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_add.kiq(1, 2)
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("tasks_sent")
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].value, 3)

--- a/tests/opentelemetry/test_metrics.py
+++ b/tests/opentelemetry/test_metrics.py
@@ -6,6 +6,7 @@ from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.test.test_base import TestBase
 
 from taskiq.instrumentation import TaskiqInstrumentor
+from taskiq.middlewares.opentelemetry_middleware import OpenTelemetryMiddleware
 
 from .taskiq_test_tasks import (
     broker,
@@ -58,6 +59,7 @@ class TestTaskiqOTelMetrics(TestBase):
             "task_success",
             "task_execution_time",
             "task_wait_time",
+            "worker_active_tasks",
         }
         found = {
             metric.name
@@ -167,3 +169,56 @@ class TestTaskiqOTelMetrics(TestBase):
         points = self._get_data_points("tasks_sent")
         self.assertEqual(len(points), 1)
         self.assertEqual(points[0].value, 3)
+
+    def test_active_tasks_counter(self) -> None:
+        async def test() -> None:
+            for _ in range(3):
+                await task_add.kiq(1, 2)
+            await broker.wait_all()
+
+        asyncio.run(test())
+
+        points = self._get_data_points("worker_active_tasks")
+        # all 3 tasks share the same task_name so they aggregate into one data point
+        self.assertEqual(len(points), 1)
+        # net zero: pre_execute incremented, post_execute decremented for each task
+        self.assertEqual(points[0].value, 0)
+        self.assertIn("task_name", points[0].attributes)
+        self.assertEqual(
+            points[0].attributes.get("task_name"),
+            "tests.opentelemetry.taskiq_test_tasks:task_add",
+        )
+
+    def test_prefetch_queue_counter(self) -> None:
+        middleware = next(
+            m for m in broker.middlewares if isinstance(m, OpenTelemetryMiddleware)
+        )
+        middleware.on_prefetch_queue_add()
+        middleware.on_prefetch_queue_add()
+        middleware.on_prefetch_queue_add()
+        middleware.on_prefetch_queue_remove()
+
+        points = self._get_data_points("worker_prefetched_tasks")
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].value, 2)
+
+    def test_worker_resource_metrics_when_worker_process(self) -> None:
+        middleware = next(
+            m for m in broker.middlewares if isinstance(m, OpenTelemetryMiddleware)
+        )
+        middleware.set_broker(broker)
+        broker.is_worker_process = True
+        try:
+            metrics_data = self.reader.get_metrics_data()
+            self.assertIsNotNone(metrics_data)
+            found = {
+                metric.name
+                for rm in metrics_data.resource_metrics  # type: ignore[union-attr]
+                for sm in rm.scope_metrics
+                for metric in sm.metrics
+            }
+            self.assertIn("worker_cpu_utilization", found)
+            self.assertIn("worker_memory_utilization", found)
+        finally:
+            broker.is_worker_process = False
+            middleware.set_broker(None)  # type: ignore[arg-type]


### PR DESCRIPTION
   ## What this adds

   This extends the existing `OpenTelemetryMiddleware` with four new metrics that give
   visibility into what a worker process is doing at runtime, not just what tasks it has
    finished.

   **Worker resource utilization** (observable gauges, worker process only):
   - `worker_cpu_utilization` — CPU usage percentage of the worker process
   - `worker_memory_utilization` — RSS memory in bytes

   Both gauges are gaurded by `broker.is_worker_process` so they stay silent in
   client/producer processes.

   **Worker queue depth** (UpDownCounters):
   - `worker_active_tasks` — number of tasks currently executing, incremented in
   `pre_execute` and decremented in `post_execute`. Carries a `task_name` attribute so
   you can see per-task concurrency.
   - `worker_prefetched_tasks` — number of tasks sitting in the internal prefetch queue
   (fetched from the broker, waiting for a worker slot). Driven by two new hooks,
   `on_prefetch_queue_add` and `on_prefetch_queue_remove`, called from the `Receiver` at
    the right points — after a real message is enqueued, and after it is dequeued but
   only once the `QUEUE_DONE` sentinel is handled so it never fires on shutdown signals.

   ## Why UpDownCounter for the queue metrics

   I didn't want to mess with the queue definition (they are local variables) so gauges where not the right thing
   since they require polling and they are not an attribute in the receiver class.   

   ## Tests

   Added tests for all four metrics to `tests/opentelemetry/test_metrics.py`:
   - `test_active_tasks_counter` — verifies net-zero value after task completion and
   `task_name` attribute correctness
   - `test_prefetch_queue_counter` — calls the hooks directly (the `Receiver` is not
   exercised by `InMemoryBroker.kiq()`) and asserts the counter value
   - `test_worker_resource_metrics_when_worker_process` — sets `is_worker_process = True` and 
   triggers an OTel collection cycle to verify the gauges yield observations. 
   If feel like this is a slight workaround but I hope it is fine.
   - `test_metrics_exist` updated to include `worker_active_tasks`