### PR TITLE
Fix InMemoryBroker to use startup and shutdown middleware hooks

### DIFF
--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, TypeVar
 
 from taskiq.abc.broker import AsyncBroker
+from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.abc.result_backend import AsyncResultBackend, TaskiqResult
 from taskiq.depends.progress_tracker import TaskProgress
 from taskiq.events import TaskiqEvents
@@ -198,9 +199,21 @@ class InMemoryBroker(AsyncBroker):
             for handler in self.event_handlers.get(event, []):
                 await maybe_awaitable(handler(self.state))
 
+        for middleware in self.middlewares:
+            if middleware.__class__.startup != TaskiqMiddleware.startup:
+                await maybe_awaitable(middleware.startup())
+
+        await self.result_backend.startup()
+
     async def shutdown(self) -> None:
         """Runs shutdown events for client and worker side."""
         for event in (TaskiqEvents.CLIENT_SHUTDOWN, TaskiqEvents.WORKER_SHUTDOWN):
             for handler in self.event_handlers.get(event, []):
                 await maybe_awaitable(handler(self.state))
+
+        for middleware in self.middlewares:
+            if middleware.__class__.shutdown != TaskiqMiddleware.shutdown:
+                await maybe_awaitable(middleware.shutdown())
+
+        await self.result_backend.shutdown()
         self.executor.shutdown()

--- a/tests/brokers/test_inmemory.py
+++ b/tests/brokers/test_inmemory.py
@@ -4,6 +4,7 @@ import uuid
 import pytest
 
 from taskiq import InMemoryBroker
+from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.events import TaskiqEvents
 from taskiq.state import TaskiqState
 
@@ -64,6 +65,24 @@ async def test_shutdown() -> None:
 
     assert broker.state.from_worker == test_value
     assert broker.state.from_client == test_value
+
+
+async def test_middleware_startup_and_shutdown_fire() -> None:
+    calls = []
+
+    class RecordingMiddleware(TaskiqMiddleware):
+        async def startup(self) -> None:
+            calls.append("startup")
+
+        async def shutdown(self) -> None:
+            calls.append("shutdown")
+
+    broker = InMemoryBroker().with_middlewares(RecordingMiddleware())
+
+    await broker.startup()
+    await broker.shutdown()
+
+    assert calls == ["startup", "shutdown"]
 
 
 async def test_execution() -> None:


### PR DESCRIPTION
A copy/paste approach + test similar to https://github.com/taskiq-python/taskiq/pull/358

Instead of relying on `super` calls this PR just copy + pastes

https://github.com/taskiq-python/taskiq/blob/9f8db96bf52947939651b4a8f0b2fdc663c6ca33/taskiq/abc/broker.py#L196-L198

and 

https://github.com/taskiq-python/taskiq/blob/9f8db96bf52947939651b4a8f0b2fdc663c6ca33/taskiq/abc/broker.py#L217-L219

into the methods of `class InMemoryBroker(AsyncBroker)` and adds a simple test case checking ensuring `startup` and `shutdown` work and the order of execution is correct.