### PR TITLE
feat: add worker-side task batching

### DIFF
--- a/docs/examples/batching/inmemory_batch.py
+++ b/docs/examples/batching/inmemory_batch.py
@@ -1,0 +1,33 @@
+# broker.py
+import asyncio
+
+from taskiq import InMemoryBroker
+
+broker = InMemoryBroker()
+
+
+@broker.task(batch=True, batch_size=100, batch_timeout=3)
+async def process_items(items: list[int]) -> int:
+    # The worker collects many `.kiq` calls and invokes this
+    # function once with the accumulated list of items.
+    print(f"Processing a batch of {len(items)} items.")
+    return sum(items)
+
+
+async def main() -> None:
+    await broker.startup()
+    # Each `.kiq` sends a single item. They are buffered and run
+    # together once the batch is flushed.
+    tasks = [await process_items.kiq(i) for i in range(10)]
+    # In tests, `wait_all` flushes any pending batches and waits
+    # for them to finish before we read the results.
+    await broker.wait_all()
+    for task in tasks:
+        result = await task.wait_result(timeout=5)
+        # Every item in the batch shares the same batch result.
+        print(f"Returned value: {result.return_value}")
+    await broker.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/batching/redis_batch.py
+++ b/docs/examples/batching/redis_batch.py
@@ -1,0 +1,32 @@
+# broker.py
+import asyncio
+
+from taskiq_redis import RedisAsyncResultBackend, RedisStreamBroker
+
+broker = RedisStreamBroker(url="redis://localhost:6379").with_result_backend(
+    RedisAsyncResultBackend(redis_url="redis://localhost:6379"),
+)
+
+
+@broker.task(batch=True, batch_size=100, batch_timeout=3)
+async def process_items(items: list[int]) -> int:
+    # The worker collects many `.kiq` calls and invokes this
+    # function once with the accumulated list of items.
+    print(f"Processing a batch of {len(items)} items.")
+    return sum(items)
+
+
+async def main() -> None:
+    await broker.startup()
+    # Each `.kiq` sends a single item. The worker buffers them and
+    # runs `process_items` once with the whole batch.
+    tasks = [await process_items.kiq(i) for i in range(10)]
+    for task in tasks:
+        result = await task.wait_result(timeout=5)
+        # Every item in the batch shares the same batch result.
+        print(f"Returned value: {result.return_value}")
+    await broker.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/guide/batching-tasks.md
+++ b/docs/guide/batching-tasks.md
@@ -5,20 +5,13 @@ order: 6
 
 # Batching tasks
 
-Some tasks have a high fixed cost per call but become much cheaper when processed
-together. Think of database writes, calls to an external API, ML inference,
-event publishing or search indexing — running them one by one wastes most of the
-time on overhead. If a single call takes ~1 second, then 10 separate calls take
-~10 seconds, but processing all 10 at once might take only ~3 seconds.
+Some tasks have a high fixed cost per call but become much cheaper when processed together. Think of database writes, calls to an external API, ML inference, event publishing or search indexing — running them one by one wastes most of the time on overhead. If a single call takes ~1 second, then 10 separate calls take ~10 seconds, but processing all 10 at once might take only ~3 seconds.
 
-Taskiq can collect many task invocations into a single batched call. Instead of
-running every message on its own, the worker buffers messages of the same task
-and executes the function once with the whole list.
+Taskiq can collect many task invocations into a single batched call. Instead of running every message on its own, the worker buffers messages of the same task and executes the function once with the whole list.
 
 ## Defining a batched task
 
-Pass `batch=True` to the `task` decorator and declare the function with a single
-parameter that receives the list of items.
+Pass `batch=True` to the `task` decorator and declare the function with a single parameter that receives the list of items.
 
 ```python
 @broker.task(batch=True, batch_size=100, batch_timeout=3)
@@ -33,14 +26,12 @@ await process_items.kiq(1)
 await process_items.kiq(2)
 ```
 
-The worker accumulates these items and calls `process_items` once with the
-collected list (e.g. `[1, 2, ...]`).
+The worker accumulates these items and calls `process_items` once with the collected list (e.g. `[1, 2, ...]`).
 
 ::: tip Typed by design
 
 `.kiq` accepts a single element, while the function body receives `list[item]`.
-Both sides are correctly typed: `process_items.kiq(1)` type-checks, but
-`process_items.kiq([1, 2])` is reported as a type error.
+Both sides are correctly typed: `process_items.kiq(1)` type-checks, but `process_items.kiq([1, 2])` is reported as a type error.
 
 :::
 
@@ -49,38 +40,25 @@ Both sides are correctly typed: `process_items.kiq(1)` type-checks, but
 A batch is sent for execution as soon as **either** condition is met:
 
 - **`batch_size`** — the buffer reaches this number of items, or
-- **`batch_timeout`** — this many seconds pass since the first item entered the
-  buffer.
+- **`batch_timeout`** — this many seconds pass since the first item entered the buffer.
 
-Whichever happens first wins. You must set at least one of the two; you can set
-both. The timer starts with the first item of a fresh buffer and resets after
-each flush. When a worker shuts down gracefully, any buffered items are flushed
-so nothing is lost.
+Whichever happens first wins. You must set at least one of the two; you can set both. The timer starts with the first item of a fresh buffer and resets after each flush. When a worker shuts down gracefully, any buffered items are flushed so nothing is lost.
 
 Each worker buffers independently and keeps a separate buffer per task name.
 
 ## Results and acknowledgement
 
-A batch produces a single result. That same return value (or error) is stored
-for **every** task in the batch, so each `.kiq` call can still await its own
-result. If the batched function raises, every task in the batch receives that
-error. Every message is acknowledged according to the configured
-[acknowledgement type](./cli.md).
+A batch produces a single result. That same return value (or error) is stored for **every** task in the batch, so each `.kiq` call can still await its own result. If the batched function raises, every task in the batch receives that error. Every message is acknowledged according to the configured [acknowledgement type](./cli.md).
 
 ::: caution Per-item granularity
 
-Batching trades per-item isolation for throughput. The whole batch shares one
-result and one fate — there are no per-item results or per-item error handling.
-A batched task must take exactly one positional argument (the list); keyword
-arguments are not part of the batched call.
+Batching trades per-item isolation for throughput. The whole batch shares one result and one fate — there are no per-item results or per-item error handling. A batched task must take exactly one positional argument (the list); keyword arguments are not part of the batched call.
 
 :::
 
 ## Trying it locally
 
-Batching is a worker-side feature, but the `InMemoryBroker` supports it too, so
-you can try it without setting up a real broker. Call `wait_all` to flush any
-pending batches and wait for them to finish before reading results.
+Batching is a worker-side feature, but the `InMemoryBroker` supports it too, so you can try it without setting up a real broker. Call `wait_all` to flush any pending batches and wait for them to finish before reading results.
 
 @[code python](../examples/batching/inmemory_batch.py)
 
@@ -95,17 +73,13 @@ Returned value: 45
 
 ::: warning InMemoryBroker behavior
 
-The `InMemoryBroker` executes tasks inplace, so batches are flushed by
-`batch_size`, by `wait_all`, or — with `await_inplace=True` — immediately as
-one-item batches. This is convenient for tests, but to see real batching across
-processes you need a distributed broker and a worker.
+The `InMemoryBroker` executes tasks inplace, so batches are flushed by `batch_size`, by `wait_all`, or — with `await_inplace=True` — immediately as one-item batches. This is convenient for tests, but to see real batching across processes you need a distributed broker and a worker.
 
 :::
 
 ## Running with a worker
 
-In production, batching happens inside the worker. Using
-[taskiq-redis](https://pypi.org/project/taskiq-redis/) as an example:
+In production, batching happens inside the worker. Using [taskiq-redis](https://pypi.org/project/taskiq-redis/) as an example:
 
 @[code python](../examples/batching/redis_batch.py)
 
@@ -115,6 +89,4 @@ Start one or more workers:
 taskiq worker broker:broker
 ```
 
-Then run the script to send items. The worker collects them and runs
-`process_items` once per batch. With several workers, each one batches the
-messages it receives independently, so the load is spread across all of them.
+Then run the script to send items. The worker collects them and runs `process_items` once per batch. With several workers, each one batches the messages it receives independently, so the load is spread across all of them.

--- a/docs/guide/batching-tasks.md
+++ b/docs/guide/batching-tasks.md
@@ -1,0 +1,120 @@
+---
+title: Batching tasks
+order: 6
+---
+
+# Batching tasks
+
+Some tasks have a high fixed cost per call but become much cheaper when processed
+together. Think of database writes, calls to an external API, ML inference,
+event publishing or search indexing — running them one by one wastes most of the
+time on overhead. If a single call takes ~1 second, then 10 separate calls take
+~10 seconds, but processing all 10 at once might take only ~3 seconds.
+
+Taskiq can collect many task invocations into a single batched call. Instead of
+running every message on its own, the worker buffers messages of the same task
+and executes the function once with the whole list.
+
+## Defining a batched task
+
+Pass `batch=True` to the `task` decorator and declare the function with a single
+parameter that receives the list of items.
+
+```python
+@broker.task(batch=True, batch_size=100, batch_timeout=3)
+async def process_items(items: list[int]) -> int:
+    return sum(items)
+```
+
+Each `.kiq` call sends a single item, exactly like a normal task:
+
+```python
+await process_items.kiq(1)
+await process_items.kiq(2)
+```
+
+The worker accumulates these items and calls `process_items` once with the
+collected list (e.g. `[1, 2, ...]`).
+
+::: tip Typed by design
+
+`.kiq` accepts a single element, while the function body receives `list[item]`.
+Both sides are correctly typed: `process_items.kiq(1)` type-checks, but
+`process_items.kiq([1, 2])` is reported as a type error.
+
+:::
+
+## When a batch is flushed
+
+A batch is sent for execution as soon as **either** condition is met:
+
+- **`batch_size`** — the buffer reaches this number of items, or
+- **`batch_timeout`** — this many seconds pass since the first item entered the
+  buffer.
+
+Whichever happens first wins. You must set at least one of the two; you can set
+both. The timer starts with the first item of a fresh buffer and resets after
+each flush. When a worker shuts down gracefully, any buffered items are flushed
+so nothing is lost.
+
+Each worker buffers independently and keeps a separate buffer per task name.
+
+## Results and acknowledgement
+
+A batch produces a single result. That same return value (or error) is stored
+for **every** task in the batch, so each `.kiq` call can still await its own
+result. If the batched function raises, every task in the batch receives that
+error. Every message is acknowledged according to the configured
+[acknowledgement type](./cli.md).
+
+::: caution Per-item granularity
+
+Batching trades per-item isolation for throughput. The whole batch shares one
+result and one fate — there are no per-item results or per-item error handling.
+A batched task must take exactly one positional argument (the list); keyword
+arguments are not part of the batched call.
+
+:::
+
+## Trying it locally
+
+Batching is a worker-side feature, but the `InMemoryBroker` supports it too, so
+you can try it without setting up a real broker. Call `wait_all` to flush any
+pending batches and wait for them to finish before reading results.
+
+@[code python](../examples/batching/inmemory_batch.py)
+
+Running this prints a single batch execution and the shared result:
+
+```bash:no-line-numbers
+$ python broker.py
+Processing a batch of 10 items.
+Returned value: 45
+... (10 times)
+```
+
+::: warning InMemoryBroker behavior
+
+The `InMemoryBroker` executes tasks inplace, so batches are flushed by
+`batch_size`, by `wait_all`, or — with `await_inplace=True` — immediately as
+one-item batches. This is convenient for tests, but to see real batching across
+processes you need a distributed broker and a worker.
+
+:::
+
+## Running with a worker
+
+In production, batching happens inside the worker. Using
+[taskiq-redis](https://pypi.org/project/taskiq-redis/) as an example:
+
+@[code python](../examples/batching/redis_batch.py)
+
+Start one or more workers:
+
+```bash:no-line-numbers
+taskiq worker broker:broker
+```
+
+Then run the script to send items. The worker collects them and runs
+`process_items` once per batch. With several workers, each one batches the
+messages it receives independently, so the load is spread across all of them.

--- a/taskiq/__init__.py
+++ b/taskiq/__init__.py
@@ -14,6 +14,7 @@ from taskiq.brokers.inmemory_broker import InMemoryBroker
 from taskiq.brokers.shared_broker import async_shared_broker
 from taskiq.brokers.zmq_broker import ZeroMQBroker
 from taskiq.context import Context
+from taskiq.decor import AsyncBatchedTaskiqDecoratedTask
 from taskiq.events import TaskiqEvents
 from taskiq.exceptions import (
     NoResultError,
@@ -41,6 +42,7 @@ __version__ = version("taskiq")
 
 __all__ = [
     "AckableMessage",
+    "AsyncBatchedTaskiqDecoratedTask",
     "AsyncBroker",
     "AsyncResultBackend",
     "AsyncTaskiqDecoratedTask",

--- a/taskiq/abc/broker.py
+++ b/taskiq/abc/broker.py
@@ -10,6 +10,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Literal,
     ParamSpec,
     TypeAlias,
     TypeVar,
@@ -21,9 +22,9 @@ from uuid import uuid4
 from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.abc.serializer import TaskiqSerializer
 from taskiq.acks import AckableMessage
-from taskiq.decor import AsyncTaskiqDecoratedTask
+from taskiq.decor import AsyncBatchedTaskiqDecoratedTask, AsyncTaskiqDecoratedTask
 from taskiq.events import TaskiqEvents
-from taskiq.exceptions import TaskBrokerMismatchError
+from taskiq.exceptions import TaskBrokerMismatchError, TaskiqBatchConfigError
 from taskiq.formatters.proxy_formatter import ProxyFormatter
 from taskiq.message import BrokerMessage
 from taskiq.result_backends.dummy import DummyResultBackend
@@ -43,6 +44,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from taskiq.abc.result_backend import AsyncResultBackend
 
 _T = TypeVar("_T")
+_Item = TypeVar("_Item")
 _FuncParams = ParamSpec("_FuncParams")
 _ReturnType = TypeVar("_ReturnType")
 
@@ -255,6 +257,40 @@ class AsyncBroker(ABC):
         :return: nothing.
         """
 
+    @staticmethod
+    def _validate_batch_labels(labels: dict[str, Any]) -> None:
+        """
+        Validate batch related labels.
+
+        :param labels: labels passed to the task decorator.
+        :raises TaskiqBatchConfigError: if batch configuration is invalid.
+        """
+        if not labels.get("batch"):
+            return
+        batch_size = labels.get("batch_size")
+        batch_timeout = labels.get("batch_timeout")
+        invalid = (
+            (batch_size is None and batch_timeout is None)
+            or (batch_size is not None and batch_size < 1)
+            or (batch_timeout is not None and batch_timeout <= 0)
+        )
+        if invalid:
+            raise TaskiqBatchConfigError
+
+    @overload
+    def task(
+        self,
+        *,
+        batch: Literal[True],
+        batch_size: int | None = None,
+        batch_timeout: float | None = None,
+        **labels: Any,
+    ) -> Callable[
+        [Callable[[list[_Item]], Awaitable[_ReturnType]]],
+        AsyncBatchedTaskiqDecoratedTask[_Item, ..., _ReturnType],
+    ]:  # pragma: no cover
+        ...
+
     @overload
     def task(
         self,
@@ -301,6 +337,7 @@ class AsyncBroker(ABC):
 
         :returns: decorator function or AsyncTaskiqDecoratedTask.
         """
+        self._validate_batch_labels(labels)
 
         def make_decorated_task(
             inner_labels: dict[str, str | int],
@@ -332,8 +369,11 @@ class AsyncBroker(ABC):
                 if "return" in sign:
                     return_type = sign["return"]
 
+                decorator_cls = self.decorator_class
+                if inner_labels.get("batch"):
+                    decorator_cls = AsyncBatchedTaskiqDecoratedTask
                 decorated_task = wrapper(
-                    self.decorator_class(
+                    decorator_cls(
                         broker=self,
                         original_func=func,
                         labels=inner_labels,

--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -225,9 +225,10 @@ class InMemoryBroker(AsyncBroker):
 
         Useful when used in testing and you need to await all sent tasks
         before asserting results. Any buffered batched tasks are flushed
-        first so their results become available too.
+        first so their results become available too. The batcher is drained
+        without being closed, so it stays usable for subsequent sends.
         """
-        await self.receiver.batcher.flush_all()
+        await self.receiver.batcher.flush_all(closing=False)
         to_await = list(self._running_tasks)
         for task in to_await:
             await task

--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -153,6 +153,10 @@ class InMemoryBroker(AsyncBroker):
 
         This method just executes given task.
 
+        For batched tasks the message is buffered and the batch is executed
+        once the batch size is reached (or immediately when `await_inplace`
+        is enabled). Call `wait_all` to flush any remaining buffered batches.
+
         :param message: incoming message.
 
         :raises TaskiqError: if someone wants to kick unknown task.
@@ -160,6 +164,11 @@ class InMemoryBroker(AsyncBroker):
         target_task = self.find_task(message.task_name)
         if target_task is None:
             raise UnknownTaskError(task_name=message.task_name)
+
+        batch_config = self.receiver.get_batch_config(message.task_name)
+        if batch_config is not None:
+            await self._kick_batched(message, batch_config)
+            return
 
         receiver_cb = self.receiver.callback(message=message.message)
         if self.await_inplace:
@@ -169,6 +178,35 @@ class InMemoryBroker(AsyncBroker):
         task = asyncio.create_task(receiver_cb)
         self._running_tasks.add(task)
         task.add_done_callback(self._running_tasks.discard)
+
+    async def _kick_batched(
+        self,
+        message: BrokerMessage,
+        batch_config: "tuple[int | None, float | None]",
+    ) -> None:
+        """
+        Buffer a batched task message and flush according to its config.
+
+        With `await_inplace` each message is flushed immediately as a
+        one-item batch so that results are available right after `kiq`.
+
+        :param message: incoming message.
+        :param batch_config: (batch_size, batch_timeout) of the task.
+        """
+        size, timeout = batch_config
+        if self.await_inplace:
+            # Flush immediately: one message becomes a one-item batch.
+            await self.receiver.batched_callback(
+                task_name=message.task_name,
+                messages=[message.message],
+            )
+            return
+        await self.receiver.batcher.add(
+            message.task_name,
+            message.message,
+            size,
+            timeout,
+        )
 
     def listen(self) -> AsyncGenerator[bytes, None]:
         """
@@ -186,11 +224,14 @@ class InMemoryBroker(AsyncBroker):
         Wait for all currently running tasks to complete.
 
         Useful when used in testing and you need to await all sent tasks
-        before asserting results.
+        before asserting results. Any buffered batched tasks are flushed
+        first so their results become available too.
         """
+        await self.receiver.batcher.flush_all()
         to_await = list(self._running_tasks)
         for task in to_await:
             await task
+        await self.receiver.wait_for_batch_tasks()
 
     async def startup(self) -> None:
         """Runs startup events for client and worker side."""

--- a/taskiq/decor.py
+++ b/taskiq/decor.py
@@ -10,6 +10,7 @@ from typing import (
     ParamSpec,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -23,6 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from taskiq.scheduler.scheduled_task import CronSpec
 
 _T = TypeVar("_T")
+_Item = TypeVar("_Item")
 _FuncParams = ParamSpec("_FuncParams")
 _ReturnType = TypeVar("_ReturnType")
 
@@ -232,3 +234,37 @@ class AsyncTaskiqDecoratedTask(Generic[_FuncParams, _ReturnType]):
 
     def __repr__(self) -> str:
         return f"AsyncTaskiqDecoratedTask({self.task_name})"
+
+
+class AsyncBatchedTaskiqDecoratedTask(
+    AsyncTaskiqDecoratedTask[_FuncParams, _ReturnType],
+    Generic[_Item, _FuncParams, _ReturnType],
+):
+    """
+    Task that is executed in batches.
+
+    The decorated function receives ``list[_Item]``, but each ``kiq`` call
+    sends a single ``_Item``. The worker accumulates these items and invokes
+    the function once with the collected list, flushing when ``batch_size`` is
+    reached or ``batch_timeout`` seconds elapse since the first buffered item.
+    """
+
+    # The base `kiq` takes the function's full params (`list[_Item]`).
+    # A batched task is enqueued one element at a time, so we deliberately
+    # narrow the signature to a single `_Item`. mypy flags this as an
+    # incompatible override, which is intended here.
+    async def kiq(  # type: ignore[override]
+        self,
+        item: _Item,
+    ) -> AsyncTaskiqTask[_ReturnType]:
+        """
+        Send a single item to be processed as part of a batch.
+
+        :param item: one element that becomes a member of the batched list.
+        :returns: taskiq task for this individual message.
+        """
+        kicker = cast(
+            "AsyncKicker[..., _ReturnType]",
+            self.kicker(),
+        )
+        return await kicker.kiq(item)

--- a/taskiq/exceptions.py
+++ b/taskiq/exceptions.py
@@ -107,3 +107,12 @@ class TaskBrokerMismatchError(TaskRejectedError):
 
     __template__ = "Task already has a different broker ({broker})"
     broker: Any
+
+
+class TaskiqBatchConfigError(TaskiqError):
+    """Error if the batch configuration of a task is invalid."""
+
+    __template__ = (
+        "Invalid batch configuration: when batch=True you must provide a "
+        "positive batch_size and/or a positive batch_timeout."
+    )

--- a/taskiq/receiver/batcher.py
+++ b/taskiq/receiver/batcher.py
@@ -1,0 +1,110 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from logging import getLogger
+from typing import Any
+
+logger = getLogger(__name__)
+
+FlushCallback = Callable[[str, list[Any]], Awaitable[None]]
+
+
+@dataclass
+class _Buffer:
+    items: list[Any] = field(default_factory=list)
+    timer: asyncio.TimerHandle | None = None
+
+
+class Batcher:
+    """
+    Accumulates items per task name and flushes them on size or timeout.
+
+    The first item added to an empty buffer arms the timeout timer (when a
+    timeout is configured). Reaching ``batch_size`` flushes immediately and
+    cancels the pending timer. ``flush_all`` drains every buffer and is used
+    on shutdown so buffered items are not lost.
+    """
+
+    def __init__(self, flush_cb: FlushCallback) -> None:
+        self._flush_cb = flush_cb
+        self._buffers: dict[str, _Buffer] = {}
+        # Tasks spawned by timeout timers. Kept so they aren't garbage
+        # collected mid-flight and so their errors are retrieved/logged.
+        self._timer_tasks: set[asyncio.Task[None]] = set()
+
+    async def add(
+        self,
+        task_name: str,
+        item: Any,
+        batch_size: int | None,
+        batch_timeout: float | None,
+    ) -> None:
+        """
+        Add one item to the named buffer, flushing if a trigger fires.
+
+        :param task_name: name of the batched task.
+        :param item: item to buffer (opaque to the batcher).
+        :param batch_size: flush when the buffer reaches this size.
+        :param batch_timeout: flush this many seconds after the first item.
+        """
+        buf = self._buffers.get(task_name)
+        if buf is None:
+            buf = _Buffer()
+            self._buffers[task_name] = buf
+
+        was_empty = not buf.items
+        buf.items.append(item)
+
+        if was_empty and batch_timeout is not None:
+            loop = asyncio.get_running_loop()
+            buf.timer = loop.call_later(
+                batch_timeout,
+                self._spawn_timer_flush,
+                task_name,
+            )
+
+        if batch_size is not None and len(buf.items) >= batch_size:
+            await self._flush(task_name)
+
+    def _spawn_timer_flush(self, task_name: str) -> None:
+        """
+        Spawn the timeout-driven flush as a tracked task.
+
+        The task is retained until it finishes and its result is retrieved in
+        a done-callback so timeout-flush errors are logged instead of being
+        silently swallowed by the event loop.
+
+        :param task_name: name of the batched task to flush.
+        """
+        task = asyncio.ensure_future(self._flush(task_name))
+        self._timer_tasks.add(task)
+
+        def _done(finished: "asyncio.Task[None]") -> None:
+            self._timer_tasks.discard(finished)
+            if not finished.cancelled():
+                exc = finished.exception()
+                if exc is not None:
+                    logger.error(
+                        "Timeout flush for batched task %s failed: %s",
+                        task_name,
+                        exc,
+                        exc_info=exc,
+                    )
+
+        task.add_done_callback(_done)
+
+    async def flush_all(self) -> None:
+        """Flush every non-empty buffer."""
+        for task_name in list(self._buffers):
+            await self._flush(task_name)
+
+    async def _flush(self, task_name: str) -> None:
+        buf = self._buffers.get(task_name)
+        if buf is None or not buf.items:
+            return
+        if buf.timer is not None:
+            buf.timer.cancel()
+            buf.timer = None
+        items = buf.items
+        buf.items = []
+        await self._flush_cb(task_name, items)

--- a/taskiq/receiver/batcher.py
+++ b/taskiq/receiver/batcher.py
@@ -6,7 +6,7 @@ from typing import Any
 
 logger = getLogger(__name__)
 
-FlushCallback = Callable[[str, list[Any]], Awaitable[None]]
+FlushCallback = Callable[..., Awaitable[None]]
 
 
 @dataclass
@@ -17,20 +17,19 @@ class _Buffer:
 
 class Batcher:
     """
-    Accumulates items per task name and flushes them on size or timeout.
+    Buffers items per task name and flushes them on size or timeout.
 
-    The first item added to an empty buffer arms the timeout timer (when a
-    timeout is configured). Reaching ``batch_size`` flushes immediately and
-    cancels the pending timer. ``flush_all`` drains every buffer and is used
-    on shutdown so buffered items are not lost.
+    The first item arms the timeout timer; reaching ``batch_size`` flushes
+    immediately. ``flush_all`` drains everything (used on shutdown).
     """
 
     def __init__(self, flush_cb: FlushCallback) -> None:
         self._flush_cb = flush_cb
         self._buffers: dict[str, _Buffer] = {}
-        # Tasks spawned by timeout timers. Kept so they aren't garbage
-        # collected mid-flight and so their errors are retrieved/logged.
+        # Kept so timer tasks aren't GC'd mid-flight and their errors surface.
         self._timer_tasks: set[asyncio.Task[None]] = set()
+        # When True, new timer flushes are not spawned (set on shutdown).
+        self._closing = False
 
     async def add(
         self,
@@ -40,11 +39,11 @@ class Batcher:
         batch_timeout: float | None,
     ) -> None:
         """
-        Add one item to the named buffer, flushing if a trigger fires.
+        Buffer one item, flushing the batch if size or timeout triggers.
 
         :param task_name: name of the batched task.
         :param item: item to buffer (opaque to the batcher).
-        :param batch_size: flush when the buffer reaches this size.
+        :param batch_size: flush once the buffer reaches this size.
         :param batch_timeout: flush this many seconds after the first item.
         """
         buf = self._buffers.get(task_name)
@@ -68,14 +67,15 @@ class Batcher:
 
     def _spawn_timer_flush(self, task_name: str) -> None:
         """
-        Spawn the timeout-driven flush as a tracked task.
+        Run the timeout-driven flush as a tracked task.
 
-        The task is retained until it finishes and its result is retrieved in
-        a done-callback so timeout-flush errors are logged instead of being
-        silently swallowed by the event loop.
+        Kept in ``_timer_tasks`` so the flush isn't GC'd and its errors are
+        logged instead of swallowed by the loop.
 
         :param task_name: name of the batched task to flush.
         """
+        if self._closing:
+            return
         task = asyncio.ensure_future(self._flush(task_name))
         self._timer_tasks.add(task)
 
@@ -93,12 +93,32 @@ class Batcher:
 
         task.add_done_callback(_done)
 
-    async def flush_all(self) -> None:
-        """Flush every non-empty buffer."""
-        for task_name in list(self._buffers):
-            await self._flush(task_name)
+    async def flush_all(self, closing: bool = True) -> None:
+        """
+        Drain every buffer and wait for in-flight timer flushes.
 
-    async def _flush(self, task_name: str) -> None:
+        With ``closing=True`` (shutdown, the default) the batcher is closed for
+        good: no new timer flushes are spawned and buffers drain via the
+        shutdown path. With ``closing=False`` (the ``wait_all`` test drain) the
+        batcher stays usable afterwards, so later ``add`` calls can re-arm
+        timers.
+
+        :param closing: permanently close the batcher (shutdown).
+        """
+        if closing:
+            self._closing = True
+        # Cancel timers that haven't fired yet; we flush their buffers now.
+        for buf in self._buffers.values():
+            if buf.timer is not None:
+                buf.timer.cancel()
+                buf.timer = None
+        for task_name in list(self._buffers):
+            await self._flush(task_name, shutdown=closing)
+        # Wait for timer flushes that were already in flight.
+        if self._timer_tasks:
+            await asyncio.gather(*self._timer_tasks, return_exceptions=True)
+
+    async def _flush(self, task_name: str, shutdown: bool = False) -> None:
         buf = self._buffers.get(task_name)
         if buf is None or not buf.items:
             return
@@ -107,4 +127,7 @@ class Batcher:
             buf.timer = None
         items = buf.items
         buf.items = []
-        await self._flush_cb(task_name, items)
+        if shutdown:
+            await self._flush_cb(task_name, items, shutdown=True)
+        else:
+            await self._flush_cb(task_name, items)

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -81,7 +81,7 @@ class Receiver:
         self.wait_tasks_timeout = wait_tasks_timeout
         for task in self.broker.get_all_tasks().values():
             self._prepare_task(task.task_name, task.original_func)
-        self.sem: asyncio.Semaphore | None = None
+        self.sem: asyncio.BoundedSemaphore | None = None
         if max_async_tasks is not None and max_async_tasks > 0:
             # Apply jitter to prevent all workers from hitting the limit simultaneously
             actual_limit = max_async_tasks
@@ -91,7 +91,7 @@ class Receiver:
                     0,
                     max_async_tasks_jitter,
                 )
-            self.sem = asyncio.Semaphore(actual_limit)
+            self.sem = asyncio.BoundedSemaphore(actual_limit)
         else:
             logger.warning(
                 "Setting unlimited number of async tasks "
@@ -237,13 +237,12 @@ class Receiver:
         messages: "Sequence[bytes | AckableMessage]",
     ) -> None:
         """
-        Execute a batch of accumulated messages as a single call.
+        Run a batch of accumulated messages as a single task call.
 
-        All messages must belong to the same batched task. Each message
-        contributes its first positional argument as one element of the list
-        passed to the task. The single result (or error) is stored under every
-        task_id, and every message is acknowledged according to the configured
-        AcknowledgeType.
+        All messages must belong to the same batched task. Each contributes its
+        first positional argument to the list passed to the handler. The single
+        result (or error) is stored under every task_id, and every message is
+        acked according to the configured AcknowledgeType.
 
         :param task_name: name of the batched task.
         :param messages: raw or ackable messages collected for this batch.
@@ -320,10 +319,10 @@ class Receiver:
         result: "TaskiqResult[Any]",
     ) -> None:
         """
-        Run error/post-execute middlewares and store the result for one message.
+        Run per-message middlewares and store the shared result for one message.
 
-        Shared by every message in a batch: `on_error` (on real failures),
-        `post_execute`, then result persistence with `post_save`.
+        Runs ``on_error`` (on real failures), ``post_execute``, then saves the
+        result with ``post_save``. Called for each message in a batch.
 
         :param message: parsed task message.
         :param result: shared batch result.
@@ -634,22 +633,66 @@ class Receiver:
         except Exception:
             return None
 
+    async def _acquire_batch_permit(self, task_name: str, shutdown: bool) -> bool:
+        """
+        Acquire a semaphore permit for a batch; return whether one is held.
+
+        The runtime path waits for a free permit. The shutdown path is
+        best-effort and never blocks forever, so a saturated semaphore can't
+        hang teardown; the permit is released later (in ``_flush_batch``) only
+        if it was acquired here.
+
+        :param task_name: name of the batched task (used in log messages).
+        :param shutdown: best-effort acquire during shutdown.
+        :return: whether a permit is now held.
+        """
+        if self.sem is None:
+            return False
+        if not shutdown:
+            await self.sem.acquire()
+            return True
+        # Best-effort shutdown: with no timeout configured, skip the acquire
+        # entirely rather than block forever on a held permit.
+        if self.wait_tasks_timeout is None:
+            logger.warning(
+                "No wait_tasks_timeout set; flushing batch %s without "
+                "acquiring a semaphore permit during shutdown.",
+                task_name,
+            )
+            return False
+        try:
+            await asyncio.wait_for(
+                self.sem.acquire(),
+                timeout=self.wait_tasks_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Could not acquire semaphore for batch %s during shutdown; "
+                "flushing without a permit.",
+                task_name,
+            )
+            return False
+        return True
+
     async def _flush_batch(
         self,
         task_name: str,
         messages: "Sequence[bytes | AckableMessage]",
+        shutdown: bool = False,
     ) -> None:
         """
-        Flush handler invoked by the Batcher: run a batch as one task.
+        Run a batch as one task, holding a semaphore permit while it runs.
 
-        Acquires the semaphore once for the whole batch and releases it when
-        the batch task completes.
+        During shutdown the permit is best-effort (see ``_acquire_batch_permit``):
+        the batch runs even if no permit could be acquired, and the permit is
+        released afterwards only if it was held.
 
         :param task_name: name of the batched task.
         :param messages: messages collected for this batch.
+        :param shutdown: best-effort flush during shutdown.
         """
-        if self.sem is not None:
-            await self.sem.acquire()
+        acquired = await self._acquire_batch_permit(task_name, shutdown)
+
         task = asyncio.create_task(
             self.batched_callback(task_name=task_name, messages=messages),
         )
@@ -657,7 +700,7 @@ class Receiver:
 
         def _done(finished: "asyncio.Task[Any]") -> None:
             self._batch_tasks.discard(finished)
-            if self.sem is not None:
+            if acquired and self.sem is not None:
                 self.sem.release()
 
         task.add_done_callback(_done)
@@ -712,6 +755,27 @@ class Receiver:
         # https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/
         task.add_done_callback(task_cb)
 
+    async def _shutdown_drain(self, tasks: "set[asyncio.Task[Any]]") -> None:
+        """
+        Drain buffered batches and wait for in-flight tasks on shutdown.
+
+        Flushes any buffered batches, then waits (bounded by
+        ``wait_tasks_timeout``) for both the in-flight immediate callbacks and
+        the batch tasks they produce to finish.
+
+        :param tasks: set of in-flight immediate callback tasks.
+        """
+        await self.batcher.flush_all()
+        all_tasks = tasks | self._batch_tasks
+        if not all_tasks:
+            return
+        logger.info(
+            "Waiting for %d running tasks to complete...",
+            len(all_tasks),
+        )
+        await asyncio.wait(all_tasks, timeout=self.wait_tasks_timeout)
+        logger.info("No more tasks to wait for. Shutting down.")
+
     async def runner(
         self,
         queue: "asyncio.Queue[bytes | AckableMessage]",
@@ -746,18 +810,7 @@ class Receiver:
                 self.sem_prefetch.release()
                 message = await queue.get()
                 if message is QUEUE_DONE:
-                    await self.batcher.flush_all()
-                    all_tasks = tasks | self._batch_tasks
-                    if all_tasks:
-                        logger.info(
-                            "Waiting for %d running tasks to complete...",
-                            len(all_tasks),
-                        )
-                        await asyncio.wait(
-                            all_tasks,
-                            timeout=self.wait_tasks_timeout,
-                        )
-                        logger.info("No more tasks to wait for. Shutting down.")
+                    await self._shutdown_drain(tasks)
                     break
 
                 # Custom hooks for OTel and any future instrumentations

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -19,6 +19,7 @@ from taskiq.acks import AcknowledgeType
 from taskiq.context import Context
 from taskiq.exceptions import NoResultError
 from taskiq.message import TaskiqMessage
+from taskiq.receiver.batcher import Batcher
 from taskiq.receiver.params_parser import parse_params
 from taskiq.result import TaskiqResult
 from taskiq.state import TaskiqState
@@ -98,8 +99,72 @@ class Receiver:
             )
         self.sem_prefetch = asyncio.Semaphore(max_prefetch)
         self.is_process_pool = isinstance(executor, ProcessPoolExecutor)
+        self.batcher = Batcher(self._flush_batch)
+        self._batch_tasks: set[asyncio.Task[Any]] = set()
 
-    async def callback(  # noqa: C901, PLR0912
+    async def _ack_if(
+        self,
+        message: "bytes | AckableMessage",
+        when: AcknowledgeType,
+    ) -> None:
+        """
+        Acknowledge a message if the configured ack time matches.
+
+        :param message: raw or ackable message.
+        :param when: ack time this call corresponds to.
+        """
+        if self.ack_time == when and isinstance(message, AckableMessage):
+            await maybe_awaitable(message.ack())
+
+    async def _run_post_execute(
+        self,
+        message: TaskiqMessage,
+        result: "TaskiqResult[Any]",
+    ) -> None:
+        """
+        Run `post_execute` middlewares for a single message.
+
+        :param message: parsed task message.
+        :param result: result of the execution.
+        """
+        for middleware in reversed(self.broker.middlewares):
+            if middleware.__class__.post_execute != TaskiqMiddleware.post_execute:
+                await maybe_awaitable(middleware.post_execute(message, result))
+
+    async def _save_result(
+        self,
+        message: TaskiqMessage,
+        result: "TaskiqResult[Any]",
+        raise_err: bool = False,
+    ) -> None:
+        """
+        Persist a result and run `post_save` middlewares for one message.
+
+        Skips persistence when the task asked for no result. Errors from the
+        result backend are logged, and re-raised only when `raise_err` is set.
+
+        :param message: parsed task message.
+        :param result: result to store.
+        :param raise_err: re-raise result backend errors.
+        :raises Exception: if storing fails and `raise_err` is True.
+        """
+        if isinstance(result.error, NoResultError):
+            return
+        try:
+            await self.broker.result_backend.set_result(message.task_id, result)
+            for middleware in reversed(self.broker.middlewares):
+                if middleware.__class__.post_save != TaskiqMiddleware.post_save:
+                    await maybe_awaitable(middleware.post_save(message, result))
+        except Exception as exc:
+            logger.exception(
+                "Can't set result in result backend. Cause: %s",
+                exc,
+                exc_info=True,
+            )
+            if raise_err:
+                raise
+
+    async def callback(
         self,
         message: bytes | AckableMessage,
         raise_err: bool = False,
@@ -154,54 +219,125 @@ class Receiver:
             taskiq_msg.task_id,
         )
 
-        if self.ack_time == AcknowledgeType.WHEN_RECEIVED and isinstance(
-            message,
-            AckableMessage,
-        ):
-            await maybe_awaitable(message.ack())
+        await self._ack_if(message, AcknowledgeType.WHEN_RECEIVED)
 
         result = await self.run_task(
             target=task.original_func,
             message=taskiq_msg,
         )
 
-        if self.ack_time == AcknowledgeType.WHEN_EXECUTED and isinstance(
-            message,
-            AckableMessage,
-        ):
-            await maybe_awaitable(message.ack())
+        await self._ack_if(message, AcknowledgeType.WHEN_EXECUTED)
+        await self._run_post_execute(taskiq_msg, result)
+        await self._save_result(taskiq_msg, result, raise_err=raise_err)
+        await self._ack_if(message, AcknowledgeType.WHEN_SAVED)
 
-        for middleware in reversed(self.broker.middlewares):
-            if middleware.__class__.post_execute != TaskiqMiddleware.post_execute:
-                await maybe_awaitable(middleware.post_execute(taskiq_msg, result))
+    async def batched_callback(  # noqa: C901
+        self,
+        task_name: str,
+        messages: "list[bytes | AckableMessage]",
+    ) -> None:
+        """
+        Execute a batch of accumulated messages as a single call.
 
-        try:
-            if not isinstance(result.error, NoResultError):
-                await self.broker.result_backend.set_result(taskiq_msg.task_id, result)
+        All messages must belong to the same batched task. Each message
+        contributes its first positional argument as one element of the list
+        passed to the task. The single result (or error) is stored under every
+        task_id, and every message is acknowledged according to the configured
+        AcknowledgeType.
 
-                for middleware in reversed(self.broker.middlewares):
-                    if middleware.__class__.post_save != TaskiqMiddleware.post_save:
-                        await maybe_awaitable(middleware.post_save(taskiq_msg, result))
-
-        except Exception as exc:
-            logger.exception(
-                "Can't set result in result backend. Cause: %s",
-                exc,
-                exc_info=True,
+        :param task_name: name of the batched task.
+        :param messages: raw or ackable messages collected for this batch.
+        """
+        task = self.broker.find_task(task_name)
+        if task is None:
+            logger.warning(
+                'Batched task "%s" is not found. Dropping batch.',
+                task_name,
             )
-            if raise_err:
-                raise exc
+            return
 
-        if self.ack_time == AcknowledgeType.WHEN_SAVED and isinstance(
-            message,
-            AckableMessage,
-        ):
-            await maybe_awaitable(message.ack())
+        parsed: list[TaskiqMessage] = []
+        ackables: list[AckableMessage] = []
+        for message in messages:
+            data = message.data if isinstance(message, AckableMessage) else message
+            try:
+                tmsg = self.broker.formatter.loads(message=data)
+                tmsg.parse_labels()
+            except Exception as exc:
+                logger.warning(
+                    "Cannot parse batched message: %s. Skipping.",
+                    exc,
+                    exc_info=True,
+                )
+                continue
+            parsed.append(tmsg)
+            if isinstance(message, AckableMessage):
+                ackables.append(message)
+
+        if not parsed:
+            return
+
+        for middleware in self.broker.middlewares:
+            if middleware.__class__.pre_execute != TaskiqMiddleware.pre_execute:
+                for idx, tmsg in enumerate(parsed):
+                    # Reassign so a middleware that returns a transformed
+                    # message takes effect (same as the non-batched path).
+                    parsed[idx] = await maybe_awaitable(
+                        middleware.pre_execute(tmsg),
+                    )
+
+        for ack in ackables:
+            await self._ack_if(ack, AcknowledgeType.WHEN_RECEIVED)
+
+        items = [tmsg.args[0] if tmsg.args else None for tmsg in parsed]
+        batch_message = TaskiqMessage(
+            task_id=parsed[0].task_id,
+            task_name=task_name,
+            labels=parsed[0].labels,
+            args=[items],
+            kwargs={},
+        )
+
+        # `on_error` is run per message below, not for the synthetic message.
+        result = await self.run_task(
+            target=task.original_func,
+            message=batch_message,
+            run_on_error=False,
+        )
+
+        for ack in ackables:
+            await self._ack_if(ack, AcknowledgeType.WHEN_EXECUTED)
+
+        for tmsg in parsed:
+            await self._finalize_batch_message(tmsg, result)
+
+        for ack in ackables:
+            await self._ack_if(ack, AcknowledgeType.WHEN_SAVED)
+
+    async def _finalize_batch_message(
+        self,
+        message: TaskiqMessage,
+        result: "TaskiqResult[Any]",
+    ) -> None:
+        """
+        Run error/post-execute middlewares and store the result for one message.
+
+        Shared by every message in a batch: `on_error` (on real failures),
+        `post_execute`, then result persistence with `post_save`.
+
+        :param message: parsed task message.
+        :param result: shared batch result.
+        """
+        if result.error is not None and not isinstance(result.error, NoResultError):
+            await self._run_on_error(message, result, result.error)
+        await self._run_post_execute(message, result)
+        await self._save_result(message, result)
 
     async def run_task(  # noqa: C901, PLR0912, PLR0915
         self,
         target: Callable[..., Any],
         message: TaskiqMessage,
+        run_on_error: bool = True,
     ) -> TaskiqResult[Any]:
         """
         This function actually executes functions.
@@ -219,6 +355,8 @@ class Receiver:
 
         :param target: function to execute.
         :param message: received message.
+        :param run_on_error: run `on_error` middlewares here. Batched execution
+            sets this to False and runs them per message instead.
         :return: result of execution.
         """
         loop = asyncio.get_running_loop()
@@ -348,18 +486,29 @@ class Receiver:
             labels=message.labels,
         )
         # If exception is found we execute middlewares.
-        if found_exception is not None:
-            for middleware in reversed(self.broker.middlewares):
-                if middleware.__class__.on_error != TaskiqMiddleware.on_error:
-                    await maybe_awaitable(
-                        middleware.on_error(
-                            message,
-                            result,
-                            found_exception,
-                        ),
-                    )
+        if found_exception is not None and run_on_error:
+            await self._run_on_error(message, result, found_exception)
 
         return result
+
+    async def _run_on_error(
+        self,
+        message: TaskiqMessage,
+        result: "TaskiqResult[Any]",
+        exception: BaseException,
+    ) -> None:
+        """
+        Run `on_error` middlewares for a single message.
+
+        :param message: parsed task message.
+        :param result: result of the failed execution.
+        :param exception: exception raised during execution.
+        """
+        for middleware in reversed(self.broker.middlewares):
+            if middleware.__class__.on_error != TaskiqMiddleware.on_error:
+                await maybe_awaitable(
+                    middleware.on_error(message, result, exception),
+                )
 
     async def listen(self, finish_event: asyncio.Event) -> None:  # pragma: no cover
         """
@@ -439,6 +588,132 @@ class Receiver:
         await queue.put(QUEUE_DONE)
         self.sem_prefetch.release()
 
+    def get_batch_config(
+        self,
+        task_name: str,
+    ) -> "tuple[int | None, float | None] | None":
+        """
+        Return (batch_size, batch_timeout) if the task is batched, else None.
+
+        A task with malformed batch labels is treated as non-batched (returns
+        None) and logged, so a single bad message cannot crash the runner.
+
+        :param task_name: name of the task.
+        :return: batch config tuple or None for non-batched tasks.
+        """
+        task = self.broker.find_task(task_name)
+        if task is None or not task.labels.get("batch"):
+            return None
+        size = task.labels.get("batch_size")
+        timeout = task.labels.get("batch_timeout")
+        try:
+            return (
+                int(size) if size is not None else None,
+                float(timeout) if timeout is not None else None,
+            )
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid batch config for task %s (size=%r, timeout=%r). "
+                "Treating as non-batched.",
+                task_name,
+                size,
+                timeout,
+            )
+            return None
+
+    def _peek_task_name(self, message: "bytes | AckableMessage") -> str | None:
+        """
+        Cheaply read the task name from a raw message for batch routing.
+
+        :param message: raw or ackable message.
+        :return: task name, or None if it cannot be parsed.
+        """
+        data = message.data if isinstance(message, AckableMessage) else message
+        try:
+            return self.broker.formatter.loads(message=data).task_name
+        except Exception:
+            return None
+
+    async def _flush_batch(
+        self,
+        task_name: str,
+        messages: "list[bytes | AckableMessage]",
+    ) -> None:
+        """
+        Flush handler invoked by the Batcher: run a batch as one task.
+
+        Acquires the semaphore once for the whole batch and releases it when
+        the batch task completes.
+
+        :param task_name: name of the batched task.
+        :param messages: messages collected for this batch.
+        """
+        if self.sem is not None:
+            await self.sem.acquire()
+        task = asyncio.create_task(
+            self.batched_callback(task_name=task_name, messages=messages),
+        )
+        self._batch_tasks.add(task)
+
+        def _done(finished: "asyncio.Task[Any]") -> None:
+            self._batch_tasks.discard(finished)
+            if self.sem is not None:
+                self.sem.release()
+
+        task.add_done_callback(_done)
+
+    async def wait_for_batch_tasks(self) -> None:
+        """
+        Await all currently running batch executions.
+
+        Used by inplace brokers (e.g. InMemoryBroker) so that tests can wait
+        for flushed batches to finish before asserting results.
+        """
+        for task in list(self._batch_tasks):
+            await task
+
+    async def _dispatch_message(
+        self,
+        message: "bytes | AckableMessage",
+        tasks: "set[asyncio.Task[Any]]",
+        task_cb: "Callable[[asyncio.Task[Any]], None]",
+    ) -> None:
+        """
+        Route a dequeued message to batching or immediate execution.
+
+        Batched messages are buffered (and flushed later by the Batcher);
+        everything else is executed right away via `callback`.
+
+        :param message: message taken from the prefetch queue.
+        :param tasks: set tracking in-flight immediate callbacks.
+        :param task_cb: done-callback that releases the semaphore for a task.
+        """
+        batched_name = self._peek_task_name(message)
+        cfg = (
+            self.get_batch_config(batched_name) if batched_name is not None else None
+        )
+        if batched_name is not None and cfg is not None:
+            size, timeout = cfg
+            # Buffering is not execution: release the slot acquired for this
+            # dequeue. The batch acquires its own slot at flush time.
+            if self.sem is not None:
+                self.sem.release()
+            await self.batcher.add(batched_name, message, size, timeout)
+            return
+
+        task = asyncio.create_task(
+            self.callback(message=message, raise_err=False),
+        )
+        tasks.add(task)
+
+        # We want the task to remove itself from the set when it's done.
+        #
+        # Because if we won't save it anywhere,
+        # python's GC can silently cancel task
+        # and this behaviour considered to be a Hisenbug.
+        # https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/
+        task.add_done_callback(task_cb)
+
     async def runner(
         self,
         queue: "asyncio.Queue[bytes | AckableMessage]",
@@ -473,12 +748,17 @@ class Receiver:
                 self.sem_prefetch.release()
                 message = await queue.get()
                 if message is QUEUE_DONE:
-                    # asyncio.wait will throw an error if there is nothing to wait for
-                    if tasks:
+                    await self.batcher.flush_all()
+                    all_tasks = tasks | self._batch_tasks
+                    if all_tasks:
                         logger.info(
-                            f"Waiting for {len(tasks)} running tasks to complete...",
+                            "Waiting for %d running tasks to complete...",
+                            len(all_tasks),
                         )
-                        await asyncio.wait(tasks, timeout=self.wait_tasks_timeout)
+                        await asyncio.wait(
+                            all_tasks,
+                            timeout=self.wait_tasks_timeout,
+                        )
                         logger.info("No more tasks to wait for. Shutting down.")
                     break
 
@@ -489,18 +769,7 @@ class Receiver:
                             middleware.on_prefetch_queue_remove(),  # type: ignore
                         )
 
-                task = asyncio.create_task(
-                    self.callback(message=message, raise_err=False),
-                )
-                tasks.add(task)
-
-                # We want the task to remove itself from the set when it's done.
-                #
-                # Because if we won't save it anywhere,
-                # python's GC can silently cancel task
-                # and this behaviour considered to be a Hisenbug.
-                # https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/
-                task.add_done_callback(task_cb)
+                await self._dispatch_message(message, tasks, task_cb)
 
             except asyncio.CancelledError:
                 break

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 import random
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import Executor, ProcessPoolExecutor
 from logging import getLogger
 from time import time
@@ -234,7 +234,7 @@ class Receiver:
     async def batched_callback(  # noqa: C901
         self,
         task_name: str,
-        messages: "list[bytes | AckableMessage]",
+        messages: "Sequence[bytes | AckableMessage]",
     ) -> None:
         """
         Execute a batch of accumulated messages as a single call.
@@ -637,7 +637,7 @@ class Receiver:
     async def _flush_batch(
         self,
         task_name: str,
-        messages: "list[bytes | AckableMessage]",
+        messages: "Sequence[bytes | AckableMessage]",
     ) -> None:
         """
         Flush handler invoked by the Batcher: run a batch as one task.
@@ -689,9 +689,7 @@ class Receiver:
         :param task_cb: done-callback that releases the semaphore for a task.
         """
         batched_name = self._peek_task_name(message)
-        cfg = (
-            self.get_batch_config(batched_name) if batched_name is not None else None
-        )
+        cfg = self.get_batch_config(batched_name) if batched_name is not None else None
         if batched_name is not None and cfg is not None:
             size, timeout = cfg
             # Buffering is not execution: release the slot acquired for this

--- a/tests/brokers/test_inmemory.py
+++ b/tests/brokers/test_inmemory.py
@@ -114,3 +114,70 @@ async def test_wait_all() -> None:
     assert slept
     assert await task.is_ready()
     assert not broker._running_tasks
+
+
+async def test_batch_flush_on_size() -> None:
+    broker = InMemoryBroker()
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=3)
+    async def batched(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    tasks = [await batched.kiq(i) for i in range(3)]
+    results = [await t.wait_result(timeout=2) for t in tasks]
+
+    assert seen == [[0, 1, 2]]
+    assert [r.return_value for r in results] == [3, 3, 3]
+
+
+async def test_batch_flush_on_wait_all() -> None:
+    broker = InMemoryBroker()
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=100, batch_timeout=30)
+    async def batched(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    # Fewer than batch_size, so nothing runs until we flush.
+    tasks = [await batched.kiq(i) for i in (10, 20)]
+    assert seen == []
+
+    await broker.wait_all()
+
+    assert seen == [[10, 20]]
+    results = [await t.wait_result(timeout=2) for t in tasks]
+    assert [r.return_value for r in results] == [30, 30]
+
+
+async def test_batch_await_inplace_flushes_immediately() -> None:
+    broker = InMemoryBroker(await_inplace=True)
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=100, batch_timeout=30)
+    async def batched(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    task = await batched.kiq(7)
+    # With await_inplace each kiq flushes a one-item batch right away.
+    assert seen == [[7]]
+    assert await task.is_ready()
+    result = await task.wait_result(timeout=2)
+    assert result.return_value == 7
+
+
+async def test_batch_error_marks_all() -> None:
+    broker = InMemoryBroker()
+
+    @broker.task(batch=True, batch_size=2)
+    async def batched(items: list[int]) -> int:
+        raise ValueError("boom")
+
+    tasks = [await batched.kiq(i) for i in (1, 2)]
+    results = [await t.wait_result(timeout=2) for t in tasks]
+
+    assert all(r.is_err for r in results)
+

--- a/tests/brokers/test_inmemory.py
+++ b/tests/brokers/test_inmemory.py
@@ -169,6 +169,36 @@ async def test_batch_await_inplace_flushes_immediately() -> None:
     assert result.return_value == 7
 
 
+async def test_batch_timer_flush_after_wait_all() -> None:
+    """wait_all must not permanently disable timeout-based flushing.
+
+    wait_all drains buffers for testing but must leave the batcher usable.
+    After a first wait_all, a new batch armed with a timeout must still flush
+    on timeout. Before the fix, flush_all sets _closing forever, so the timer
+    never fires again and ``seen`` stays [[1]] (RED).
+    """
+    broker = InMemoryBroker()
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=100, batch_timeout=0.05)
+    async def batched(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    await batched.kiq(1)
+    await broker.wait_all()
+    assert seen == [[1]]
+
+    # New batch after wait_all; the timer alone must flush it (no second
+    # wait_all, otherwise the drain would mask a dead timer).
+    await batched.kiq(2)
+    await batched.kiq(3)
+    await asyncio.sleep(0.15)
+
+    assert seen == [[1], [2, 3]]
+    await broker.wait_all()
+
+
 async def test_batch_error_marks_all() -> None:
     broker = InMemoryBroker()
 

--- a/tests/brokers/test_inmemory.py
+++ b/tests/brokers/test_inmemory.py
@@ -180,4 +180,3 @@ async def test_batch_error_marks_all() -> None:
     results = [await t.wait_result(timeout=2) for t in tasks]
 
     assert all(r.is_err for r in results)
-

--- a/tests/receiver/test_batch_callback.py
+++ b/tests/receiver/test_batch_callback.py
@@ -1,0 +1,333 @@
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from taskiq import InMemoryBroker
+from taskiq.abc.middleware import TaskiqMiddleware
+from taskiq.acks import AckableMessage, AcknowledgeType
+from taskiq.message import TaskiqMessage
+from taskiq.receiver import Receiver
+from taskiq.receiver.receiver import QUEUE_DONE
+from taskiq.result import TaskiqResult
+
+
+def _msg(broker: InMemoryBroker, name: str, item: int) -> bytes:
+    return broker.formatter.dumps(
+        TaskiqMessage(
+            task_id=f"id-{item}",
+            task_name=name,
+            labels={},
+            args=[item],
+            kwargs={},
+        ),
+    ).message
+
+
+def _receiver(
+    broker: InMemoryBroker,
+    ack_type: AcknowledgeType | None = None,
+    max_async_tasks: int = 10,
+) -> Receiver:
+    return Receiver(
+        broker,
+        executor=ThreadPoolExecutor(max_workers=4),
+        max_async_tasks=max_async_tasks,
+        ack_type=ack_type,
+    )
+
+
+async def test_batch_callback_collects_items() -> None:
+    broker = InMemoryBroker()
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=3)
+    async def my_task(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    receiver = _receiver(broker)
+    msgs = [_msg(broker, my_task.task_name, i) for i in range(3)]
+    await receiver.batched_callback(my_task.task_name, msgs)
+    assert seen == [[0, 1, 2]]
+
+
+async def test_batch_result_stored_for_each_task_id() -> None:
+    broker = InMemoryBroker()
+
+    @broker.task(batch=True, batch_size=2)
+    async def my_task(items: list[int]) -> int:
+        return sum(items)
+
+    receiver = _receiver(broker)
+    msgs = [_msg(broker, my_task.task_name, i) for i in (10, 20)]
+    await receiver.batched_callback(my_task.task_name, msgs)
+
+    r0 = await broker.result_backend.get_result("id-10")
+    r1 = await broker.result_backend.get_result("id-20")
+    assert r0.return_value == 30
+    assert r1.return_value == 30
+
+
+async def test_batch_acks_each_message() -> None:
+    broker = InMemoryBroker()
+    acked: list[int] = []
+
+    @broker.task(batch=True, batch_size=2)
+    async def my_task(items: list[int]) -> int:
+        return sum(items)
+
+    receiver = _receiver(broker)
+
+    def make_ack(i: int) -> Callable[[], None]:
+        def _ack() -> None:
+            acked.append(i)
+        return _ack
+
+    msgs = [
+        AckableMessage(data=_msg(broker, my_task.task_name, i), ack=make_ack(i))
+        for i in (1, 2)
+    ]
+    await receiver.batched_callback(my_task.task_name, msgs)
+    assert sorted(acked) == [1, 2]
+
+
+async def test_batch_error_marks_all() -> None:
+    broker = InMemoryBroker()
+
+    @broker.task(batch=True, batch_size=2)
+    async def my_task(items: list[int]) -> int:
+        raise ValueError("boom")
+
+    receiver = _receiver(broker)
+    msgs = [_msg(broker, my_task.task_name, i) for i in (1, 2)]
+    await receiver.batched_callback(my_task.task_name, msgs)
+
+    r0 = await broker.result_backend.get_result("id-1")
+    r1 = await broker.result_backend.get_result("id-2")
+    assert r0.is_err
+    assert r1.is_err
+
+
+async def test_batch_unknown_task_is_safe() -> None:
+    broker = InMemoryBroker()
+    receiver = _receiver(broker)
+    # Should not raise even though there are no messages / unknown task.
+    await receiver.batched_callback("does.not.exist", [])
+
+
+async def test_runner_routes_and_flushes_on_shutdown() -> None:
+    broker = InMemoryBroker()
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=5, batch_timeout=0.05)
+    async def my_task(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    receiver = _receiver(broker)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    for i in (1, 2):
+        await queue.put(_msg(broker, my_task.task_name, i))
+    await queue.put(QUEUE_DONE)
+
+    await receiver.runner(queue)
+    await asyncio.sleep(0.1)
+
+    assert seen == [[1, 2]]
+
+
+async def test_runner_flushes_on_size_during_run() -> None:
+    broker = InMemoryBroker()
+    seen: list[list[int]] = []
+
+    @broker.task(batch=True, batch_size=2)
+    async def my_task(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    receiver = _receiver(broker)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    for i in (1, 2):
+        await queue.put(_msg(broker, my_task.task_name, i))
+    await queue.put(QUEUE_DONE)
+
+    await receiver.runner(queue)
+    await asyncio.sleep(0.05)
+
+    assert seen == [[1, 2]]
+
+
+async def test_runner_still_runs_normal_tasks() -> None:
+    broker = InMemoryBroker()
+    calls: list[int] = []
+
+    @broker.task
+    async def normal_task(x: int) -> int:
+        calls.append(x)
+        return x
+
+    receiver = _receiver(broker)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_msg(broker, normal_task.task_name, 7))
+    await queue.put(QUEUE_DONE)
+
+    await receiver.runner(queue)
+    await asyncio.sleep(0.05)
+
+    assert calls == [7]
+
+
+async def test_batch_on_error_runs_per_message() -> None:
+    """on_error must fire once per message in the batch, not once per batch."""
+    errored: list[str] = []
+
+    class _ErrMiddleware(TaskiqMiddleware):
+        def on_error(
+            self,
+            message: TaskiqMessage,
+            result: "TaskiqResult[Any]",
+            exception: BaseException,
+        ) -> None:
+            errored.append(message.task_id)
+
+    broker = InMemoryBroker().with_middlewares(_ErrMiddleware())
+
+    @broker.task(batch=True, batch_size=3)
+    async def my_task(items: list[int]) -> int:
+        raise ValueError("boom")
+
+    receiver = _receiver(broker)
+    msgs = [_msg(broker, my_task.task_name, i) for i in range(3)]
+    await receiver.batched_callback(my_task.task_name, msgs)
+
+    assert sorted(errored) == ["id-0", "id-1", "id-2"]
+
+
+async def test_batch_pre_execute_transformation_is_applied() -> None:
+    """A pre_execute middleware that returns a new message must take effect."""
+    seen: list[list[int]] = []
+
+    class _TransformMiddleware(TaskiqMiddleware):
+        def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
+            # Double the single item carried by each message.
+            message.args = [message.args[0] * 2]
+            return message
+
+    broker = InMemoryBroker().with_middlewares(_TransformMiddleware())
+
+    @broker.task(batch=True, batch_size=3)
+    async def my_task(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    receiver = _receiver(broker)
+    msgs = [_msg(broker, my_task.task_name, i) for i in (1, 2, 3)]
+    await receiver.batched_callback(my_task.task_name, msgs)
+
+    assert seen == [[2, 4, 6]]
+
+
+async def test_batch_acks_when_received() -> None:
+    broker = InMemoryBroker()
+    acked: list[int] = []
+
+    @broker.task(batch=True, batch_size=2)
+    async def my_task(items: list[int]) -> int:
+        # Record ack order relative to execution.
+        acked.append(-1)
+        return sum(items)
+
+    receiver = _receiver(broker, ack_type=AcknowledgeType.WHEN_RECEIVED)
+
+    def make_ack(i: int) -> Callable[[], None]:
+        def _ack() -> None:
+            acked.append(i)
+        return _ack
+
+    msgs = [
+        AckableMessage(data=_msg(broker, my_task.task_name, i), ack=make_ack(i))
+        for i in (1, 2)
+    ]
+    await receiver.batched_callback(my_task.task_name, msgs)
+
+    # Both messages acked, and acks happened before execution.
+    assert sorted(x for x in acked if x != -1) == [1, 2]
+    assert acked.index(1) < acked.index(-1)
+    assert acked.index(2) < acked.index(-1)
+
+
+async def test_batch_acks_when_executed() -> None:
+    broker = InMemoryBroker()
+    acked: list[int] = []
+
+    @broker.task(batch=True, batch_size=2)
+    async def my_task(items: list[int]) -> int:
+        acked.append(-1)
+        return sum(items)
+
+    receiver = _receiver(broker, ack_type=AcknowledgeType.WHEN_EXECUTED)
+
+    def make_ack(i: int) -> Callable[[], None]:
+        def _ack() -> None:
+            acked.append(i)
+        return _ack
+
+    msgs = [
+        AckableMessage(data=_msg(broker, my_task.task_name, i), ack=make_ack(i))
+        for i in (1, 2)
+    ]
+    await receiver.batched_callback(my_task.task_name, msgs)
+
+    assert sorted(x for x in acked if x != -1) == [1, 2]
+    # Acks happened after execution.
+    assert acked.index(-1) < acked.index(1)
+    assert acked.index(-1) < acked.index(2)
+
+
+async def test_buffering_not_blocked_by_saturated_semaphore() -> None:
+    """Batched messages buffer freely even when the semaphore is exhausted."""
+    broker = InMemoryBroker()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    seen: list[list[int]] = []
+
+    @broker.task
+    async def blocker(x: int) -> int:
+        started.set()
+        await release.wait()
+        return x
+
+    @broker.task(batch=True, batch_size=3)
+    async def my_task(items: list[int]) -> int:
+        seen.append(items)
+        return sum(items)
+
+    # Only one concurrent slot.
+    receiver = _receiver(broker, max_async_tasks=1)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_msg(broker, blocker.task_name, 99))
+    # These 3 batched messages must buffer and flush even though the single
+    # semaphore slot is held by `blocker`.
+    for i in range(3):
+        await queue.put(_msg(broker, my_task.task_name, i))
+
+    runner_task = asyncio.create_task(receiver.runner(queue))
+
+    # Wait for the blocker to occupy the only slot.
+    await asyncio.wait_for(started.wait(), timeout=2)
+    # Give the runner time to drain the 3 batched messages into the buffer
+    # and flush them (the batch waits for the slot at flush time).
+    await asyncio.sleep(0.2)
+
+    # Buffering happened (not blocked); the batch flush is now waiting for the
+    # semaphore held by `blocker`. Release the blocker so everything finishes.
+    release.set()
+    await queue.put(QUEUE_DONE)
+    await asyncio.wait_for(runner_task, timeout=2)
+
+    assert seen == [[0, 1, 2]]

--- a/tests/receiver/test_batch_callback.py
+++ b/tests/receiver/test_batch_callback.py
@@ -82,6 +82,7 @@ async def test_batch_acks_each_message() -> None:
     def make_ack(i: int) -> Callable[[], None]:
         def _ack() -> None:
             acked.append(i)
+
         return _ack
 
     msgs = [
@@ -127,7 +128,7 @@ async def test_runner_routes_and_flushes_on_shutdown() -> None:
 
     receiver = _receiver(broker)
 
-    queue: asyncio.Queue = asyncio.Queue()
+    queue: asyncio.Queue[bytes | AckableMessage] = asyncio.Queue()
     for i in (1, 2):
         await queue.put(_msg(broker, my_task.task_name, i))
     await queue.put(QUEUE_DONE)
@@ -149,7 +150,7 @@ async def test_runner_flushes_on_size_during_run() -> None:
 
     receiver = _receiver(broker)
 
-    queue: asyncio.Queue = asyncio.Queue()
+    queue: asyncio.Queue[bytes | AckableMessage] = asyncio.Queue()
     for i in (1, 2):
         await queue.put(_msg(broker, my_task.task_name, i))
     await queue.put(QUEUE_DONE)
@@ -171,7 +172,7 @@ async def test_runner_still_runs_normal_tasks() -> None:
 
     receiver = _receiver(broker)
 
-    queue: asyncio.Queue = asyncio.Queue()
+    queue: asyncio.Queue[bytes | AckableMessage] = asyncio.Queue()
     await queue.put(_msg(broker, normal_task.task_name, 7))
     await queue.put(QUEUE_DONE)
 
@@ -246,6 +247,7 @@ async def test_batch_acks_when_received() -> None:
     def make_ack(i: int) -> Callable[[], None]:
         def _ack() -> None:
             acked.append(i)
+
         return _ack
 
     msgs = [
@@ -274,6 +276,7 @@ async def test_batch_acks_when_executed() -> None:
     def make_ack(i: int) -> Callable[[], None]:
         def _ack() -> None:
             acked.append(i)
+
         return _ack
 
     msgs = [
@@ -309,7 +312,7 @@ async def test_buffering_not_blocked_by_saturated_semaphore() -> None:
     # Only one concurrent slot.
     receiver = _receiver(broker, max_async_tasks=1)
 
-    queue: asyncio.Queue = asyncio.Queue()
+    queue: asyncio.Queue[bytes | AckableMessage] = asyncio.Queue()
     await queue.put(_msg(broker, blocker.task_name, 99))
     # These 3 batched messages must buffer and flush even though the single
     # semaphore slot is held by `blocker`.

--- a/tests/receiver/test_batch_callback.py
+++ b/tests/receiver/test_batch_callback.py
@@ -291,6 +291,62 @@ async def test_batch_acks_when_executed() -> None:
     assert acked.index(-1) < acked.index(2)
 
 
+async def test_shutdown_does_not_hang_when_semaphore_saturated() -> None:
+    """Shutdown batch flush must not block forever on sem.acquire.
+
+    All semaphore permits are held (here: the only permit is acquired
+    externally to simulate long-running normal tasks at shutdown). A batched
+    message is buffered. The shutdown flush path must complete within
+    wait_tasks_timeout instead of blocking forever on the held permit.
+    """
+    broker = InMemoryBroker()
+
+    @broker.task(batch=True, batch_size=5, batch_timeout=None)
+    async def my_task(items: list[int]) -> int:
+        return sum(items)
+
+    receiver = _receiver(broker, max_async_tasks=1)
+    receiver.wait_tasks_timeout = 0.2
+
+    # Buffer one batched message (size 5 not reached -> only flush_all drains it).
+    msg = _msg(broker, my_task.task_name, 1)
+    await receiver.batcher.add(my_task.task_name, msg, 5, None)
+
+    # Exhaust the single permit, as if a long-running normal task held it.
+    assert receiver.sem is not None
+    await receiver.sem.acquire()
+
+    # Shutdown flush. Before the fix this blocks forever on sem.acquire inside
+    # _flush_batch; wait_for would then time out (RED). After the fix it
+    # proceeds without the permit within wait_tasks_timeout.
+    await asyncio.wait_for(receiver.batcher.flush_all(), timeout=2)
+
+
+async def test_shutdown_does_not_hang_when_no_wait_timeout_set() -> None:
+    """With wait_tasks_timeout=None, shutdown must still not block on sem.
+
+    wait_for(acquire(), timeout=None) would wait forever, so the shutdown
+    path must skip the permit entirely when no timeout is configured.
+    """
+    broker = InMemoryBroker()
+
+    @broker.task(batch=True, batch_size=5, batch_timeout=None)
+    async def my_task(items: list[int]) -> int:
+        return sum(items)
+
+    receiver = _receiver(broker, max_async_tasks=1)
+    # Default: no wait_tasks_timeout.
+    assert receiver.wait_tasks_timeout is None
+
+    msg = _msg(broker, my_task.task_name, 1)
+    await receiver.batcher.add(my_task.task_name, msg, 5, None)
+
+    assert receiver.sem is not None
+    await receiver.sem.acquire()
+
+    await asyncio.wait_for(receiver.batcher.flush_all(), timeout=2)
+
+
 async def test_buffering_not_blocked_by_saturated_semaphore() -> None:
     """Batched messages buffer freely even when the semaphore is exhausted."""
     broker = InMemoryBroker()

--- a/tests/receiver/test_batcher.py
+++ b/tests/receiver/test_batcher.py
@@ -75,7 +75,7 @@ async def test_fresh_buffer_after_flush() -> None:
 async def test_flush_all_drains_buffers() -> None:
     flushed: list[list[int]] = []
 
-    async def flush(name: str, items: list[int]) -> None:
+    async def flush(name: str, items: list[int], shutdown: bool = False) -> None:
         flushed.append(items)
 
     batcher = Batcher(flush)
@@ -87,9 +87,99 @@ async def test_flush_all_drains_buffers() -> None:
 async def test_flush_all_empty_is_noop() -> None:
     flushed: list[list[int]] = []
 
-    async def flush(name: str, items: list[int]) -> None:
+    async def flush(name: str, items: list[int], shutdown: bool = False) -> None:
         flushed.append(items)
 
     batcher = Batcher(flush)
     await batcher.flush_all()
     assert flushed == []
+
+
+async def test_flush_all_non_closing_leaves_batcher_usable() -> None:
+    """A non-closing drain (wait_all path) must keep the batcher operational.
+
+    flush_all(closing=False) drains buffers like a test-time flush but must NOT
+    permanently close the batcher: a subsequent ``add`` that arms a timer must
+    still fire. It must also use the normal (non-shutdown) flush path, so the
+    callback is never invoked with shutdown=True. Before the fix, flush_all sets
+    _closing=True forever, so the second timer never fires (RED).
+    """
+    flushed: list[list[int]] = []
+    shutdown_flags: list[bool] = []
+
+    async def flush(name: str, items: list[int], shutdown: bool = False) -> None:
+        flushed.append(items)
+        shutdown_flags.append(shutdown)
+
+    batcher = Batcher(flush)
+
+    # First item, arm a timer, then drain via the non-closing path.
+    await batcher.add("t", 1, batch_size=None, batch_timeout=0.01)
+    await batcher.flush_all(closing=False)
+    assert flushed == [[1]]
+    assert batcher._closing is False
+    # The non-closing drain must NOT have used the shutdown flush path.
+    assert shutdown_flags == [False]
+
+    # Now the batcher must still be usable: a new timer-armed add must fire.
+    await batcher.add("t", 2, batch_size=None, batch_timeout=0.01)
+    await asyncio.sleep(0.05)
+    assert flushed == [[1], [2]]
+    assert shutdown_flags == [False, False]
+
+
+async def test_flush_all_default_closes_batcher() -> None:
+    """Default flush_all (closing=True) keeps shutdown semantics: closes forever.
+
+    After a default flush_all, _closing is True and _spawn_timer_flush no-ops.
+    """
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int], shutdown: bool = False) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    await batcher.add("t", 1, batch_size=10, batch_timeout=None)
+    await batcher.flush_all()
+    assert flushed == [[1]]
+    assert batcher._closing is True
+
+    # Late timer spawns must be no-ops after close.
+    batcher._spawn_timer_flush("t")
+    assert batcher._timer_tasks == set()
+
+
+async def test_flush_all_awaits_inflight_timer_tasks() -> None:
+    """Shutdown must drain timer-spawned flushes, not leak them.
+
+    A timer fires and spawns a flush task whose callback is slow. flush_all
+    drains the buffer (a no-op since the timer already swapped the items) and
+    must wait for the in-flight timer task to finish, leaving no pending timer
+    tasks behind. Before the fix, flush_all ignores _timer_tasks entirely, so
+    the in-flight timer flush is still pending when flush_all returns.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def flush(name: str, items: list[int], shutdown: bool = False) -> None:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+
+    batcher = Batcher(flush)
+    await batcher.add("t", 1, batch_size=None, batch_timeout=0.01)
+
+    # Let the timer fire and spawn the flush task; it now blocks in `flush`.
+    await asyncio.wait_for(started.wait(), timeout=1)
+    assert len(batcher._timer_tasks) == 1
+
+    # Let the blocked flush finish concurrently with the shutdown drain.
+    release.set()
+    await batcher.flush_all()
+
+    # After shutdown, no timer task may remain pending and the single batch
+    # must have flushed exactly once.
+    assert not batcher._timer_tasks
+    assert calls == 1

--- a/tests/receiver/test_batcher.py
+++ b/tests/receiver/test_batcher.py
@@ -1,0 +1,95 @@
+import asyncio
+
+from taskiq.receiver.batcher import Batcher
+
+
+async def test_flush_on_size() -> None:
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    for i in range(3):
+        await batcher.add("t", i, batch_size=3, batch_timeout=None)
+
+    await asyncio.sleep(0)
+    assert flushed == [[0, 1, 2]]
+
+
+async def test_flush_on_timeout() -> None:
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    await batcher.add("t", 1, batch_size=None, batch_timeout=0.05)
+    assert flushed == []
+    await asyncio.sleep(0.1)
+    assert flushed == [[1]]
+
+
+async def test_size_cancels_timer() -> None:
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    await batcher.add("t", 1, batch_size=2, batch_timeout=10)
+    await batcher.add("t", 2, batch_size=2, batch_timeout=10)
+    await asyncio.sleep(0)
+    assert flushed == [[1, 2]]
+    await asyncio.sleep(0.05)
+    assert flushed == [[1, 2]]
+
+
+async def test_separate_buffers_per_task_name() -> None:
+    flushed: list[tuple[str, list[int]]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append((name, items))
+
+    batcher = Batcher(flush)
+    await batcher.add("a", 1, batch_size=1, batch_timeout=None)
+    await batcher.add("b", 2, batch_size=1, batch_timeout=None)
+    await asyncio.sleep(0)
+    assert ("a", [1]) in flushed
+    assert ("b", [2]) in flushed
+
+
+async def test_fresh_buffer_after_flush() -> None:
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    await batcher.add("t", 1, batch_size=1, batch_timeout=None)
+    await batcher.add("t", 2, batch_size=1, batch_timeout=None)
+    await asyncio.sleep(0)
+    assert flushed == [[1], [2]]
+
+
+async def test_flush_all_drains_buffers() -> None:
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    await batcher.add("t", 1, batch_size=10, batch_timeout=None)
+    await batcher.flush_all()
+    assert flushed == [[1]]
+
+
+async def test_flush_all_empty_is_noop() -> None:
+    flushed: list[list[int]] = []
+
+    async def flush(name: str, items: list[int]) -> None:
+        flushed.append(items)
+
+    batcher = Batcher(flush)
+    await batcher.flush_all()
+    assert flushed == []

--- a/tests/test_batch_config.py
+++ b/tests/test_batch_config.py
@@ -1,0 +1,39 @@
+import pytest
+
+from taskiq import InMemoryBroker
+from taskiq.exceptions import TaskiqBatchConfigError
+
+
+def test_batch_without_size_or_timeout_raises() -> None:
+    broker = InMemoryBroker()
+    with pytest.raises(TaskiqBatchConfigError):
+
+        @broker.task(batch=True)
+        async def my_task(items: list[int]) -> None: ...
+
+
+def test_batch_size_must_be_positive() -> None:
+    broker = InMemoryBroker()
+    with pytest.raises(TaskiqBatchConfigError):
+
+        @broker.task(batch=True, batch_size=0)
+        async def my_task(items: list[int]) -> None: ...
+
+
+def test_batch_timeout_must_be_positive() -> None:
+    broker = InMemoryBroker()
+    with pytest.raises(TaskiqBatchConfigError):
+
+        @broker.task(batch=True, batch_timeout=0)
+        async def my_task(items: list[int]) -> None: ...
+
+
+def test_valid_batch_config_ok() -> None:
+    broker = InMemoryBroker()
+
+    @broker.task(batch=True, batch_size=10, batch_timeout=2)
+    async def my_task(items: list[int]) -> None: ...
+
+    assert my_task.labels["batch"] is True
+    assert my_task.labels["batch_size"] == 10
+    assert my_task.labels["batch_timeout"] == 2


### PR DESCRIPTION
Allow grouping same-type tasks into batches that are executed together, reducing per-call overhead for tasks like DB writes, external API calls, ML inference, event publishing and indexing.

Usage:

```python
@broker.task(batch=True, batch_size=100, batch_timeout=3)
async def process_items(items: list[Item]) -> None:
    ...

await process_items.kiq(item)  # one item per kiq
```

Each .kiq sends a single item; the worker buffers messages per task name and invokes the function once with the collected list. A batch is flushed when batch_size is reached or batch_timeout seconds pass since the first buffered item (whichever comes first), and on graceful shutdown.

Details:
- AsyncBatchedTaskiqDecoratedTask types .kiq to accept a single element while the function body receives list[item].
- Batch config is validated at registration (TaskiqBatchConfigError).
- The whole batch shares one result, stored under every task_id, and every message is acked per the configured AcknowledgeType. pre_execute, post_execute, post_save and on_error middlewares run per message.
- InMemoryBroker supports batching too (flush on size, on wait_all, or immediately when await_inplace=True) for testing.