### PR TITLE
Add per-task ack type support

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -58,6 +58,21 @@ This can be configured using `--ack-type` parameter. For example:
 taskiq worker --ack-type when_executed mybroker:broker
 ```
 
+It can also be overridden per task using the `ack_type` task label:
+
+```python
+@broker.task(ack_type="when_received")
+async def best_effort_task() -> None:
+    ...
+
+
+@broker.task(ack_type="when_saved")
+async def critical_task() -> None:
+    ...
+```
+
+If a task has no `ack_type` label, the worker-level `--ack-type` value is used.
+
 ### Type casts
 
 One of features taskiq have is automatic type casts. For example you have a type-hinted task like this:

--- a/taskiq/__init__.py
+++ b/taskiq/__init__.py
@@ -9,7 +9,7 @@ from taskiq.abc.formatter import TaskiqFormatter
 from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.abc.result_backend import AsyncResultBackend
 from taskiq.abc.schedule_source import ScheduleSource
-from taskiq.acks import AckableMessage
+from taskiq.acks import AckableMessage, AcknowledgeType
 from taskiq.brokers.inmemory_broker import InMemoryBroker
 from taskiq.brokers.shared_broker import async_shared_broker
 from taskiq.brokers.zmq_broker import ZeroMQBroker
@@ -41,6 +41,7 @@ __version__ = version("taskiq")
 
 __all__ = [
     "AckableMessage",
+    "AcknowledgeType",
     "AsyncBroker",
     "AsyncResultBackend",
     "AsyncTaskiqDecoratedTask",

--- a/taskiq/acks.py
+++ b/taskiq/acks.py
@@ -1,5 +1,6 @@
 import enum
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -18,6 +19,20 @@ class AcknowledgeType(str, enum.Enum):
     # acknowledged when the task will be saved
     # only after it's saved in the result backend.
     WHEN_SAVED = "when_saved"
+
+
+def parse_acknowledge_type(value: Any) -> AcknowledgeType:
+    """Parse acknowledge type from a task label value."""
+    if isinstance(value, AcknowledgeType):
+        return value
+    if isinstance(value, str):
+        try:
+            return AcknowledgeType(value.lower())
+        except ValueError as exc:
+            raise ValueError(f"Unknown acknowledge type value: {value}.") from exc
+    raise ValueError(
+        f"Unsupported acknowledge type: {value} use str or AcknowledgeType",
+    )
 
 
 class AckableMessage(BaseModel):

--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -15,7 +15,7 @@ from taskiq_dependencies import DependencyGraph
 
 from taskiq.abc.broker import AckableMessage, AsyncBroker
 from taskiq.abc.middleware import TaskiqMiddleware
-from taskiq.acks import AcknowledgeType
+from taskiq.acks import AcknowledgeType, parse_acknowledge_type
 from taskiq.context import Context
 from taskiq.exceptions import NoResultError
 from taskiq.message import TaskiqMessage
@@ -148,13 +148,14 @@ class Receiver:
                     ),
                 )
 
+        ack_time = self._get_ack_time(taskiq_msg)
         logger.info(
             "Executing task %s with ID: %s",
             taskiq_msg.task_name,
             taskiq_msg.task_id,
         )
 
-        if self.ack_time == AcknowledgeType.WHEN_RECEIVED and isinstance(
+        if ack_time == AcknowledgeType.WHEN_RECEIVED and isinstance(
             message,
             AckableMessage,
         ):
@@ -165,7 +166,7 @@ class Receiver:
             message=taskiq_msg,
         )
 
-        if self.ack_time == AcknowledgeType.WHEN_EXECUTED and isinstance(
+        if ack_time == AcknowledgeType.WHEN_EXECUTED and isinstance(
             message,
             AckableMessage,
         ):
@@ -192,11 +193,27 @@ class Receiver:
             if raise_err:
                 raise exc
 
-        if self.ack_time == AcknowledgeType.WHEN_SAVED and isinstance(
+        if ack_time == AcknowledgeType.WHEN_SAVED and isinstance(
             message,
             AckableMessage,
         ):
             await maybe_awaitable(message.ack())
+
+    def _get_ack_time(self, message: TaskiqMessage) -> AcknowledgeType:
+        """
+        Get acknowledge time for a task.
+
+        Task-level `ack_type` label overrides worker-level configuration.
+        """
+        ack_type = message.labels.get("ack_type")
+        if ack_type is None:
+            return self.ack_time
+        try:
+            return parse_acknowledge_type(ack_type)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid ack_type label {ack_type!r} for task {message.task_name}.",
+            ) from exc
 
     async def run_task(  # noqa: C901, PLR0912, PLR0915
         self,

--- a/tests/receiver/test_receiver.py
+++ b/tests/receiver/test_receiver.py
@@ -13,6 +13,8 @@ from taskiq_dependencies import Depends
 
 from taskiq.abc.broker import AckableMessage, AsyncBroker
 from taskiq.abc.middleware import TaskiqMiddleware
+from taskiq.abc.result_backend import AsyncResultBackend
+from taskiq.acks import AcknowledgeType
 from taskiq.brokers.inmemory_broker import InMemoryBroker
 from taskiq.exceptions import NoResultError, TaskiqResultTimeoutError
 from taskiq.message import TaskiqMessage
@@ -26,6 +28,7 @@ def get_receiver(
     no_parse: bool = False,
     max_async_tasks: int | None = None,
     max_async_tasks_jitter: int = 0,
+    ack_type: AcknowledgeType | None = None,
 ) -> Receiver:
     """
     Returns receiver with custom broker and args.
@@ -44,7 +47,48 @@ def get_receiver(
         validate_params=not no_parse,
         max_async_tasks=max_async_tasks,
         max_async_tasks_jitter=max_async_tasks_jitter,
+        ack_type=ack_type,
     )
+
+
+class _EventResultBackend(AsyncResultBackend[Any]):
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.results: dict[str, TaskiqResult[Any]] = {}
+
+    async def set_result(self, task_id: str, result: TaskiqResult[Any]) -> None:
+        self.events.append("save")
+        self.results[task_id] = result
+
+    async def is_result_ready(self, task_id: str) -> bool:
+        return task_id in self.results
+
+    async def get_result(
+        self,
+        task_id: str,
+        with_logs: bool = False,
+    ) -> TaskiqResult[Any]:
+        return self.results[task_id]
+
+
+class _EventMiddleware(TaskiqMiddleware):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    def post_execute(
+        self,
+        message: TaskiqMessage,
+        result: TaskiqResult[Any],
+    ) -> None:
+        self.events.append("post_execute")
+
+    def post_save(
+        self,
+        message: TaskiqMessage,
+        result: TaskiqResult[Any],
+    ) -> None:
+        self.events.append("post_save")
 
 
 async def test_run_task_successful_async() -> None:
@@ -325,6 +369,192 @@ async def test_callback_success_ackable_async() -> None:
     )
     assert called_times == 1
     assert acked
+
+
+async def test_task_ack_type_when_received_overrides_worker_ack_type() -> None:
+    """Task ack_type label overrides worker-level ack type."""
+    events: list[str] = []
+    broker = (
+        InMemoryBroker()
+        .with_result_backend(
+            _EventResultBackend(events),
+        )
+        .with_middlewares(_EventMiddleware(events))
+    )
+
+    @broker.task
+    async def my_task() -> int:
+        events.append("task")
+        return 1
+
+    def ack_callback() -> None:
+        events.append("ack")
+
+    receiver = get_receiver(broker, ack_type=AcknowledgeType.WHEN_SAVED)
+    broker_message = broker.formatter.dumps(
+        TaskiqMessage(
+            task_id="task_id",
+            task_name=my_task.task_name,
+            labels={"ack_type": "when_received"},
+            args=[],
+            kwargs={},
+        ),
+    )
+
+    await receiver.callback(
+        AckableMessage(
+            data=broker_message.message,
+            ack=ack_callback,
+        ),
+    )
+
+    assert events == ["ack", "task", "post_execute", "save", "post_save"]
+
+
+async def test_task_ack_type_when_executed_overrides_worker_ack_type() -> None:
+    """Task ack_type label can delay a worker-level when_received ack."""
+    events: list[str] = []
+    broker = (
+        InMemoryBroker()
+        .with_result_backend(
+            _EventResultBackend(events),
+        )
+        .with_middlewares(_EventMiddleware(events))
+    )
+
+    @broker.task(ack_type="when_executed")
+    async def my_task() -> int:
+        events.append("task")
+        return 1
+
+    def ack_callback() -> None:
+        events.append("ack")
+
+    receiver = get_receiver(broker, ack_type=AcknowledgeType.WHEN_RECEIVED)
+    broker_message = broker.formatter.dumps(my_task.kicker()._prepare_message())
+
+    await receiver.callback(
+        AckableMessage(
+            data=broker_message.message,
+            ack=ack_callback,
+        ),
+    )
+
+    assert events == ["task", "ack", "post_execute", "save", "post_save"]
+
+
+async def test_task_ack_type_when_saved_overrides_worker_ack_type() -> None:
+    """Task ack_type label can use when_saved with an early-ack worker."""
+    events: list[str] = []
+    broker = (
+        InMemoryBroker()
+        .with_result_backend(
+            _EventResultBackend(events),
+        )
+        .with_middlewares(_EventMiddleware(events))
+    )
+
+    @broker.task
+    async def my_task() -> int:
+        events.append("task")
+        return 1
+
+    def ack_callback() -> None:
+        events.append("ack")
+
+    receiver = get_receiver(broker, ack_type=AcknowledgeType.WHEN_RECEIVED)
+    broker_message = broker.formatter.dumps(
+        TaskiqMessage(
+            task_id="task_id",
+            task_name=my_task.task_name,
+            labels={"ack_type": "when_saved"},
+            args=[],
+            kwargs={},
+        ),
+    )
+
+    await receiver.callback(
+        AckableMessage(
+            data=broker_message.message,
+            ack=ack_callback,
+        ),
+    )
+
+    assert events == ["task", "post_execute", "save", "post_save", "ack"]
+
+
+async def test_worker_ack_type_is_used_without_task_ack_type() -> None:
+    """Worker-level ack_type is used when the task has no ack_type label."""
+    events: list[str] = []
+    broker = (
+        InMemoryBroker()
+        .with_result_backend(
+            _EventResultBackend(events),
+        )
+        .with_middlewares(_EventMiddleware(events))
+    )
+
+    @broker.task
+    async def my_task() -> int:
+        events.append("task")
+        return 1
+
+    def ack_callback() -> None:
+        events.append("ack")
+
+    receiver = get_receiver(broker, ack_type=AcknowledgeType.WHEN_RECEIVED)
+    broker_message = broker.formatter.dumps(
+        TaskiqMessage(
+            task_id="task_id",
+            task_name=my_task.task_name,
+            labels={},
+            args=[],
+            kwargs={},
+        ),
+    )
+
+    await receiver.callback(
+        AckableMessage(
+            data=broker_message.message,
+            ack=ack_callback,
+        ),
+    )
+
+    assert events == ["ack", "task", "post_execute", "save", "post_save"]
+
+
+async def test_invalid_task_ack_type_raises_before_execution() -> None:
+    """Invalid task ack_type fails before task execution and acknowledgement."""
+    events: list[str] = []
+    broker = InMemoryBroker()
+
+    @broker.task
+    async def my_task() -> None:
+        events.append("task")
+
+    def ack_callback() -> None:
+        events.append("ack")
+
+    receiver = get_receiver(broker, ack_type=AcknowledgeType.WHEN_RECEIVED)
+    broker_message = broker.formatter.dumps(
+        TaskiqMessage(
+            task_id="task_id",
+            task_name=my_task.task_name,
+            labels={"ack_type": "when_save"},
+            args=[],
+            kwargs={},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Invalid ack_type label"):
+        await receiver.callback(
+            AckableMessage(
+                data=broker_message.message,
+                ack=ack_callback,
+            ),
+        )
+
+    assert events == []
 
 
 async def test_callback_wrong_format() -> None:

--- a/tests/test_acks.py
+++ b/tests/test_acks.py
@@ -1,0 +1,24 @@
+import pytest
+
+from taskiq.acks import AcknowledgeType, parse_acknowledge_type
+
+
+def test_parse_acknowledge_type_from_enum() -> None:
+    assert (
+        parse_acknowledge_type(AcknowledgeType.WHEN_RECEIVED)
+        == AcknowledgeType.WHEN_RECEIVED
+    )
+
+
+def test_parse_acknowledge_type_from_string() -> None:
+    assert parse_acknowledge_type("when_executed") == AcknowledgeType.WHEN_EXECUTED
+
+
+def test_parse_acknowledge_type_unknown_string() -> None:
+    with pytest.raises(ValueError, match="Unknown acknowledge type value"):
+        parse_acknowledge_type("when_save")
+
+
+def test_parse_acknowledge_type_unsupported_value() -> None:
+    with pytest.raises(ValueError, match="Unsupported acknowledge type"):
+        parse_acknowledge_type(1)


### PR DESCRIPTION
## Summary

- Add per-task `ack_type` support via task labels, overriding worker-level `--ack-type` when present.
- Support both string values and `AcknowledgeType` enum values for task-level ack configuration.
- Export `AcknowledgeType` from `taskiq` and document the new per-task usage.

Related discussion: https://github.com/orgs/taskiq-python/discussions/635

## Testing

- `uv run pytest tests/receiver/test_receiver.py -q`
- `uv run ruff check taskiq/acks.py taskiq/receiver/receiver.py taskiq/__init__.py tests/receiver/test_receiver.py`
- `uv run mypy taskiq`
- `uv run pytest -q -x --ignore=tests/opentelemetry`
- `uv run pytest tests/opentelemetry -q`
