### PR TITLE
Fix typos in docstrings and docs

### DIFF
--- a/docs/examples/extending/schedule_source.py
+++ b/docs/examples/extending/schedule_source.py
@@ -26,7 +26,7 @@ class MyScheduleSource(ScheduleSource):
         print("New schedule added:", schedule)
 
     # This method is completely optional, but if you want to support
-    # schedule cancelation, you must implement it.
+    # schedule cancellation, you must implement it.
     async def delete_schedule(self, schedule_id: str) -> None:
         print("Deleting schedule:", schedule_id)
 

--- a/docs/guide/state-and-deps.md
+++ b/docs/guide/state-and-deps.md
@@ -278,9 +278,9 @@ async def get_transaction(
 ) -> AsyncGenerator[Transaction, None]:
     trans = db_driver.begin_transaction():
     try:
-        # Here we give transaction to our dependant function.
+        # Here we give transaction to our dependent function.
         yield trans
-    # If exception was found in dependant function,
+    # If exception was found in dependent function,
     # we rollback our transaction.
     except Exception:
         await trans.rollback()
@@ -297,9 +297,9 @@ async def get_transaction(
 ) -> AsyncGenerator[Transaction, None]:
     trans = db_driver.begin_transaction():
     try:
-        # Here we give transaction to our dependant function.
+        # Here we give transaction to our dependent function.
         yield trans
-    # If exception was found in dependant function,
+    # If exception was found in dependent function,
     # we rollback our transaction.
     except Exception:
         await trans.rollback()

--- a/taskiq/abc/schedule_source.py
+++ b/taskiq/abc/schedule_source.py
@@ -46,7 +46,7 @@ class ScheduleSource(ABC):
         """
         Method to delete schedule by id.
 
-        This is useful for schedule cancelation.
+        This is useful for schedule cancellation.
 
         :param schedule_id: id of schedule to delete.
         """


### PR DESCRIPTION
Fix a few typos found by codespell:

- `cancelation` -> `cancellation` in `taskiq/abc/schedule_source.py` and `docs/examples/extending/schedule_source.py`
- `dependant` -> `dependent` in `docs/guide/state-and-deps.md` (four occurrences)

All changes are in comments and documentation - no logic changed.