### PR TITLE
Fix post_send firing after task execution with await_inplace=True

### DIFF
--- a/taskiq/abc/broker.py
+++ b/taskiq/abc/broker.py
@@ -237,6 +237,18 @@ class AsyncBroker(ABC):
         :param message: name of a task.
         """
 
+    async def _finish_kick(self) -> None:  # noqa: B027
+        """
+        Hook that runs after a message is sent and ``post_send`` fired.
+
+        Most brokers send messages elsewhere and have nothing to do here,
+        so this is a no-op by default. Brokers that execute tasks in-place
+        (like :class:`~taskiq.InMemoryBroker` with ``await_inplace``) can
+        override this method to await the in-place execution *after* the
+        ``post_send`` middleware hook has run, preserving the expected
+        ``pre_send -> post_send -> pre_execute -> ...`` ordering.
+        """
+
     @abstractmethod
     def listen(self) -> AsyncGenerator[bytes | AckableMessage, None]:
         """

--- a/taskiq/brokers/inmemory_broker.py
+++ b/taskiq/brokers/inmemory_broker.py
@@ -146,6 +146,7 @@ class InMemoryBroker(AsyncBroker):
         )
         self.await_inplace = await_inplace
         self._running_tasks: set[asyncio.Task[Any]] = set()
+        self._inplace_tasks: set[asyncio.Task[Any]] = set()
 
     async def kick(self, message: BrokerMessage) -> None:
         """
@@ -162,13 +163,36 @@ class InMemoryBroker(AsyncBroker):
             raise UnknownTaskError(task_name=message.task_name)
 
         receiver_cb = self.receiver.callback(message=message.message)
+        task = asyncio.create_task(receiver_cb)
+
         if self.await_inplace:
-            await receiver_cb
+            # Schedule the receiver as a task instead of awaiting it here so
+            # that control returns to the sender and the ``post_send``
+            # middleware hook fires *before* the task starts executing. The
+            # task is then awaited in `_finish_kick`, right after `post_send`,
+            # keeping the in-place execution while fixing the hook ordering.
+            self._inplace_tasks.add(task)
+            task.add_done_callback(self._inplace_tasks.discard)
             return
 
-        task = asyncio.create_task(receiver_cb)
         self._running_tasks.add(task)
         task.add_done_callback(self._running_tasks.discard)
+
+    async def _finish_kick(self) -> None:
+        """
+        Await in-place task execution scheduled by `kick`.
+
+        This runs after the `post_send` middleware hook, so with
+        ``await_inplace=True`` the hook ordering becomes
+        ``pre_send -> post_send -> pre_execute -> task -> post_execute``
+        while tasks are still fully executed before `kiq` returns.
+        """
+        if not self._inplace_tasks:
+            return
+        to_await = list(self._inplace_tasks)
+        self._inplace_tasks.clear()
+        for task in to_await:
+            await task
 
     def listen(self) -> AsyncGenerator[bytes, None]:
         """

--- a/taskiq/kicker.py
+++ b/taskiq/kicker.py
@@ -169,6 +169,8 @@ class AsyncKicker(Generic[_FuncParams, _ReturnType]):
             if middleware.__class__.post_send != TaskiqMiddleware.post_send:
                 await maybe_awaitable(middleware.post_send(message))
 
+        await self.broker._finish_kick()  # noqa: SLF001
+
         return AsyncTaskiqTask(
             task_id=message.task_id,
             result_backend=self.broker.result_backend,

--- a/tests/brokers/test_inmemory.py
+++ b/tests/brokers/test_inmemory.py
@@ -4,7 +4,10 @@ import uuid
 import pytest
 
 from taskiq import InMemoryBroker
+from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.events import TaskiqEvents
+from taskiq.message import TaskiqMessage
+from taskiq.result import TaskiqResult
 from taskiq.state import TaskiqState
 
 
@@ -114,3 +117,46 @@ async def test_wait_all() -> None:
     assert slept
     assert await task.is_ready()
     assert not broker._running_tasks
+
+
+async def test_inplace_middleware_order() -> None:
+    """post_send must fire before task execution with await_inplace=True."""
+    events: list[str] = []
+
+    class OrderMiddleware(TaskiqMiddleware):
+        async def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
+            events.append("pre_send")
+            return message
+
+        async def post_send(self, message: TaskiqMessage) -> None:
+            events.append("post_send")
+
+        async def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
+            events.append("pre_execute")
+            return message
+
+        async def post_execute(
+            self,
+            message: TaskiqMessage,
+            result: "TaskiqResult[object]",
+        ) -> None:
+            events.append("post_execute")
+
+    broker = InMemoryBroker(await_inplace=True).with_middlewares(OrderMiddleware())
+
+    @broker.task
+    async def test_task() -> None:
+        events.append("task")
+
+    task = await test_task.kiq()
+
+    # The task must be fully executed by the time kiq returns.
+    assert await task.is_ready()
+    assert not broker._inplace_tasks
+    assert events == [
+        "pre_send",
+        "post_send",
+        "pre_execute",
+        "task",
+        "post_execute",
+    ]


### PR DESCRIPTION
## Summary

Fixes #586.

With `InMemoryBroker(await_inplace=True)`, the client-side `post_send` middleware hook fired **after** the task finished executing, giving the ordering:

```
pre_send -> pre_execute -> task -> post_execute -> post_send
```

instead of the expected:

```
pre_send -> post_send -> pre_execute -> task -> post_execute
```

This breaks the semantics of `post_send` (e.g. a "task queued" log ends up with a later timestamp than "task started").

### Root cause

`InMemoryBroker.kick()` awaited the full receiver callback (running `pre_execute` -> `task` -> `post_execute`) inline before control returned to `AsyncKicker.kiq()`, which only then invoked the `post_send` middleware hook.

## Fix

- `InMemoryBroker.kick()` now schedules the in-place receiver as an `asyncio.Task` and returns immediately (into a dedicated `_inplace_tasks` set) instead of awaiting it inline. This lets `post_send` run before the task starts executing.
- A new `AsyncBroker._finish_kick()` hook (a no-op by default) is awaited in `AsyncKicker.kiq()` right after the `post_send` loop. `InMemoryBroker` overrides it to await the scheduled in-place task.

The task is still fully executed before `kiq()` returns, so the existing `await_inplace` contract is preserved (result ready on return, no leftover running tasks). Other brokers are unaffected: `_finish_kick()` defaults to a no-op.

## Tests

- Added `tests/brokers/test_inmemory.py::test_inplace_middleware_order`, which asserts the hook order is `pre_send -> post_send -> pre_execute -> task -> post_execute` and that the task is fully executed by the time `kiq()` returns. This test fails on `master` and passes with the fix.
- Full suite green locally (`pytest -n auto`, 293 passed), plus `black`, `ruff`, and `mypy` (strict) all clean.

Disclosure: prepared with AI assistance; reviewed and verified locally.