### PR TITLE
fix(receiver): ack messages that cannot be parsed or resolved

### DIFF
--- a/taskiq/receiver/receiver.py
+++ b/taskiq/receiver/receiver.py
@@ -130,6 +130,8 @@ class Receiver:
                 exc,
                 exc_info=True,
             )
+            if ack_controller.is_ackable:
+                await ack_controller.ack()
             return
         logger.debug(f"Received message: {taskiq_msg}")
         task = self.broker.find_task(taskiq_msg.task_name)
@@ -138,6 +140,8 @@ class Receiver:
                 'task "%s" is not found. Maybe you forgot to import it?',
                 taskiq_msg.task_name,
             )
+            if ack_controller.is_ackable:
+                await ack_controller.ack()
             return
         logger.debug(
             "Function for task %s is resolved. Executing...",

--- a/tests/receiver/test_receiver.py
+++ b/tests/receiver/test_receiver.py
@@ -334,6 +334,56 @@ async def test_callback_success_ackable() -> None:
     assert acked
 
 
+async def test_callback_acks_unknown_task() -> None:
+    """Test that a message for an unknown task is acked, not left pending."""
+    broker = InMemoryBroker()
+    acked = False
+
+    def ack_callback() -> None:
+        nonlocal acked
+        acked = True
+
+    receiver = get_receiver(broker)
+
+    broker_message = broker.formatter.dumps(
+        TaskiqMessage(
+            task_id="task_id",
+            task_name="unknown_task_name",
+            labels={},
+            args=[],
+            kwargs={},
+        ),
+    )
+
+    await receiver.callback(
+        AckableMessage(
+            data=broker_message.message,
+            ack=ack_callback,
+        ),
+    )
+    assert acked
+
+
+async def test_callback_acks_unparsable_message() -> None:
+    """Test that an unparsable message is acked, not left pending."""
+    broker = InMemoryBroker()
+    acked = False
+
+    def ack_callback() -> None:
+        nonlocal acked
+        acked = True
+
+    receiver = get_receiver(broker)
+
+    await receiver.callback(
+        AckableMessage(
+            data=b"not a valid taskiq message",
+            ack=ack_callback,
+        ),
+    )
+    assert acked
+
+
 async def test_callback_success_ackable_async() -> None:
     """Test that acks work with async functions."""
     broker = InMemoryBroker()


### PR DESCRIPTION
Closes #569

When `Receiver.callback` cannot parse a message, or the named task is not registered, it logged a warning and returned without acking. For ackable brokers the message was already prefetched out of the queue, so it stayed pending forever - purging the queue did not clear it, and it only reappeared when the consumer was terminated.

Both early-return paths now ack the message when it is ackable: neither an unparsable payload nor a missing task becomes processable on redelivery.

Regression tests added for both paths; they fail on master (message never acked) and pass with the fix.
