### PR TITLE
fix(task): tolerate transient result backend errors in wait_result

### DIFF
--- a/taskiq/task.py
+++ b/taskiq/task.py
@@ -78,6 +78,7 @@ class AsyncTaskiqTask(Generic[_ReturnType]):
         check_interval: float = 0.2,
         timeout: float = -1.0,
         with_logs: bool = False,
+        max_poll_failures: int = 3,
     ) -> "TaskiqResult[_ReturnType]":
         """
         Waits until result is ready.
@@ -89,15 +90,43 @@ class AsyncTaskiqTask(Generic[_ReturnType]):
         task didn't become ready in provided
         period of time.
 
+        Failing readiness checks are tolerated while they look
+        transient. The counter is reset by every successful check, so
+        the wait is only aborted after max_poll_failures checks have
+        failed in a row.
+
         :param check_interval: How often checks are performed.
         :param timeout: timeout for the result.
         :param with_logs: whether you want to fetch logs from worker.
+        :param max_poll_failures: how many readiness checks may fail
+            in a row before giving up. Pass 0 to give up on the first
+            failed check.
         :raises TaskiqResultTimeoutError: if task didn't
             become ready in provided period of time.
+        :raises ResultIsReadyError: if readiness checks kept failing.
         :return: task's return value.
         """
         start_time = time()
-        while not await self.is_ready():
+        failures = 0
+        while True:
+            try:
+                ready = await self.is_ready()
+            except ResultIsReadyError:
+                failures += 1
+                if failures > max_poll_failures:
+                    raise
+                logger.warning(
+                    "Cannot check readiness of task %s, "
+                    "retrying (%d of %d attempts used).",
+                    self.task_id,
+                    failures,
+                    max_poll_failures,
+                    exc_info=True,
+                )
+            else:
+                if ready:
+                    break
+                failures = 0
             if 0 < timeout < time() - start_time:
                 raise TaskiqResultTimeoutError(timeout=timeout)
             await asyncio.sleep(check_interval)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -8,6 +8,7 @@ from taskiq import serializers
 from taskiq.abc import AsyncResultBackend
 from taskiq.abc.serializer import TaskiqSerializer
 from taskiq.compat import model_dump, model_validate
+from taskiq.exceptions import ResultIsReadyError, TaskiqResultTimeoutError
 from taskiq.result import TaskiqResult
 from taskiq.task import AsyncTaskiqTask
 
@@ -69,3 +70,101 @@ async def test_res_parsing_success(serializer: TaskiqSerializer) -> None:
     sent_task = AsyncTaskiqTask(test_id, res_back, MyResult)
     parsed = await sent_task.wait_result()
     assert isinstance(parsed.return_value, MyResult)
+
+
+class ScriptedBackend(AsyncResultBackend[str]):
+    """Backend whose readiness checks follow a fixed script.
+
+    Each item of the script is either a value to return or an exception
+    to raise. The last item repeats once the script runs out.
+    """
+
+    def __init__(self, script: list[bool | Exception]) -> None:
+        self.script = script
+        self.polls = 0
+
+    async def set_result(
+        self,
+        task_id: str,
+        result: TaskiqResult[str],
+    ) -> None:
+        """Results are produced by the script, so nothing is stored."""
+
+    async def is_result_ready(self, task_id: str) -> bool:
+        """Perform the next scripted readiness check."""
+        step = self.script[min(self.polls, len(self.script) - 1)]
+        self.polls += 1
+        if isinstance(step, Exception):
+            raise step
+        return step
+
+    async def get_result(
+        self,
+        task_id: str,
+        with_logs: bool = False,
+    ) -> TaskiqResult[str]:
+        """Return a fixed successful result."""
+        return TaskiqResult(is_err=False, return_value="done", execution_time=0.0)
+
+
+async def test_wait_result_survives_transient_error() -> None:
+    backend = ScriptedBackend([ConnectionError("connection reset"), True])
+    task: AsyncTaskiqTask[str] = AsyncTaskiqTask("task-id", backend)
+
+    result = await task.wait_result(check_interval=0.0)
+
+    assert result.return_value == "done"
+    assert backend.polls == 2
+
+
+async def test_wait_result_raises_if_backend_never_recovers() -> None:
+    backend = ScriptedBackend([ConnectionError("backend is down")])
+    task: AsyncTaskiqTask[str] = AsyncTaskiqTask("task-id", backend)
+
+    with pytest.raises(ResultIsReadyError):
+        await task.wait_result(check_interval=0.0, max_poll_failures=2)
+
+    # Two tolerated failures, then the third one is fatal.
+    assert backend.polls == 3
+
+
+async def test_wait_result_counts_failures_consecutively() -> None:
+    backend = ScriptedBackend(
+        [
+            ConnectionError("connection reset"),
+            False,
+            ConnectionError("connection reset"),
+            False,
+            ConnectionError("connection reset"),
+            True,
+        ],
+    )
+    task: AsyncTaskiqTask[str] = AsyncTaskiqTask("task-id", backend)
+
+    # Three failures in total, but never two in a row.
+    result = await task.wait_result(check_interval=0.0, max_poll_failures=1)
+
+    assert result.return_value == "done"
+    assert backend.polls == 6
+
+
+async def test_wait_result_no_retries_by_configuration() -> None:
+    backend = ScriptedBackend([ConnectionError("connection reset"), True])
+    task: AsyncTaskiqTask[str] = AsyncTaskiqTask("task-id", backend)
+
+    with pytest.raises(ResultIsReadyError):
+        await task.wait_result(check_interval=0.0, max_poll_failures=0)
+
+    assert backend.polls == 1
+
+
+async def test_wait_result_timeout_while_retrying() -> None:
+    backend = ScriptedBackend([ConnectionError("backend is down")])
+    task: AsyncTaskiqTask[str] = AsyncTaskiqTask("task-id", backend)
+
+    with pytest.raises(TaskiqResultTimeoutError):
+        await task.wait_result(
+            check_interval=0.05,
+            timeout=0.1,
+            max_poll_failures=1000,
+        )


### PR DESCRIPTION
## Why

Refs #655.

`AsyncTaskiqTask.wait_result` polls `is_ready()` in a loop with no handler, and
`is_ready()` wraps every result backend exception in `ResultIsReadyError`. One
failed poll therefore ends the wait, even though the `timeout` budget is
untouched and the task itself is fine. With a network-backed result backend, a
single Redis read timeout, failover or connection reset is enough to trigger it.

The loop now counts consecutive failures. Any successful check resets the
count, and the error is re-raised once `max_poll_failures` (new parameter,
default 3) checks have failed in a row. Each tolerated failure is logged at
warning level with the traceback.

Counting consecutively, rather than retrying until the `timeout` budget runs
out, is deliberate. `timeout` defaults to `-1.0`, which means wait forever, so
spending the budget would turn a loud error into a silent hang for the most
likely real cause: the backend is down.
`tests/test_funcs.py::test_gather_result_backend_error` already pins the
behaviour for that case, using a mock that fails on every call. Bounding by
consecutive failures fixes the transient case from the issue and leaves that
intact, and it behaves the same whether or not a timeout is set.

The issue also offers an opt-in flag as the more conservative option. I went
with a bounded default instead, because the issue describes a bug, and a flag
that is off by default leaves that bug in place for everyone who does not go
looking for it. `max_poll_failures=0` restores today's behaviour exactly,
which is the same escape hatch pointed the other way.

The default of 3 matches `default_retry_count` in `simple_retry_middleware.py`
and `smart_retry_middleware.py`.

One consequence worth naming: `is_ready()` converts every backend exception
into `ResultIsReadyError`, so a genuine bug in a custom backend is now retried
as well, and surfaces after `max_poll_failures + 1` checks rather than on the
first. It does still surface, with the original exception as `__cause__`.
Narrowing `is_ready()` would be the real answer to that and would change the
contract every third-party result backend is written against, so it is not in
this PR.

## What this deliberately leaves

This PR is narrower than the issue it refers to, so the issue should stay open
after it merges. The report also notes that `get_result()` has the same shape,
and a blip in the window between "ready" and the read still raises
`ResultGetError` out of `wait_result`. I left it out because it is a different
decision rather than the same one twice: once the backend has reported ready, a
failed read can mean the result expired, `result_ex_time` being set, just as
easily as it can mean the connection blipped, and retrying then waits out a
result that is never coming.

`gather()` in `taskiq/funcs.py` has the readiness defect too. Fixing it means
changing `test_gather_result_backend_error`, which currently asserts the fatal
behaviour, so it is a behaviour change with its own argument.

Backing `check_interval` off while the backend is erroring, which the issue
suggests as well, would need a backoff convention the library does not have
yet.

Happy to send any of the three as a follow-up, in whatever order is useful.

## Testing

`uv run pytest -q -n auto .` gives 302 passed, against 297 on master.

Five tests were added to `tests/test_task.py`, using the hand-rolled backend
style already in that file: one transient failure then ready, a backend that
never recovers (still raises, and does not hang), failures separated by
successful polls (the counter resets), `max_poll_failures=0`, and a timeout set
while retrying (`TaskiqResultTimeoutError` still wins).

`uv run pre-commit run -a black`, `... ruff` and `... mypy` all pass.
