### PR TITLE
Feat/scheduler plugins

### DIFF
--- a/docs/examples/extending/scheduler_plugin.py
+++ b/docs/examples/extending/scheduler_plugin.py
@@ -1,8 +1,8 @@
 from taskiq import (
     InMemoryBroker,
     ScheduledTask,
-    ScheduleSource,
     SchedulerPlugin,
+    ScheduleSource,
     TaskiqScheduler,
 )
 from taskiq.schedule_sources import LabelScheduleSource

--- a/docs/examples/extending/scheduler_plugin.py
+++ b/docs/examples/extending/scheduler_plugin.py
@@ -1,0 +1,29 @@
+from taskiq import (
+    InMemoryBroker,
+    ScheduledTask,
+    ScheduleSource,
+    SchedulerPlugin,
+    TaskiqScheduler,
+)
+from taskiq.schedule_sources import LabelScheduleSource
+
+broker = InMemoryBroker()
+
+
+class MyPlugin(SchedulerPlugin):
+    def on_schedules_updated(
+        self,
+        source: ScheduleSource,
+        schedules: list[ScheduledTask],
+    ) -> None:
+        print(f"Source {source} returned {len(schedules)} schedules.")
+
+    async def post_send(self, source: ScheduleSource, task: ScheduledTask) -> None:
+        print(f"Task {task.task_name} was sent with schedule_id {task.schedule_id}.")
+
+
+scheduler = TaskiqScheduler(
+    broker=broker,
+    sources=[LabelScheduleSource(broker)],
+    plugins=[MyPlugin()],
+)

--- a/docs/extending-taskiq/scheduler-plugin.md
+++ b/docs/extending-taskiq/scheduler-plugin.md
@@ -36,3 +36,9 @@ Also, plugins always have a reference to the current scheduler in the
 `self.scheduler` field. You can use it to access the broker or all
 schedule sources, for example to kick a task or delete a schedule
 during the execution of some plugin hook.
+
+Taskiq ships one built-in plugin:
+`taskiq.scheduler_plugins.TaskiqAdminSchedulerPlugin` — the scheduler
+counterpart of `TaskiqAdminMiddleware`. It syncs all schedules and
+registered tasks with the [taskiq-admin](https://github.com/taskiq-python/taskiq-admin)
+panel and applies delete / reschedule / trigger commands created in its UI.

--- a/docs/extending-taskiq/scheduler-plugin.md
+++ b/docs/extending-taskiq/scheduler-plugin.md
@@ -1,0 +1,38 @@
+---
+order: 6
+---
+
+# Scheduler plugins
+
+Scheduler plugins observe the scheduler's lifecycle. They are useful for
+monitoring, tracing or synchronizing schedules with external systems,
+like admin panels.
+
+To create a new `scheduler plugin` you have to subclass the
+[`taskiq.abc.scheduler_plugin.SchedulerPlugin`](https://github.com/taskiq-python/taskiq/blob/master/taskiq/abc/scheduler_plugin.py) class.
+Every method of a plugin can be either sync or async. Taskiq will execute it
+as you expect.
+
+Plugins are observers. Unlike schedule sources they cannot cancel or modify
+tasks, and exceptions raised from the `on_schedules_updated`, `pre_send` and
+`post_send` hooks are logged and suppressed, so a failing plugin never breaks
+scheduling.
+
+Available hooks:
+
+- `startup` - called during the scheduler's startup.
+- `shutdown` - called during the scheduler's shutdown.
+- `on_schedules_updated` - called when schedules are refreshed from a source.
+  The scheduler refreshes all its sources on startup and then periodically,
+  based on its update interval.
+- `pre_send` - called right before a scheduled task is sent.
+- `post_send` - called right after a scheduled task is sent.
+
+For example:
+
+@[code python](../examples/extending/scheduler_plugin.py)
+
+Also, plugins always have a reference to the current scheduler in the
+`self.scheduler` field. You can use it to access the broker or all
+schedule sources, for example to kick a task or delete a schedule
+during the execution of some plugin hook.

--- a/taskiq/__init__.py
+++ b/taskiq/__init__.py
@@ -9,6 +9,7 @@ from taskiq.abc.formatter import TaskiqFormatter
 from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.abc.result_backend import AsyncResultBackend
 from taskiq.abc.schedule_source import ScheduleSource
+from taskiq.abc.scheduler_plugin import SchedulerPlugin
 from taskiq.acks import AckableMessage, AcknowledgeType
 from taskiq.brokers.inmemory_broker import InMemoryBroker
 from taskiq.brokers.shared_broker import async_shared_broker
@@ -55,6 +56,7 @@ __all__ = [
     "ResultIsReadyError",
     "ScheduleSource",
     "ScheduledTask",
+    "SchedulerPlugin",
     "SecurityError",
     "SendTaskError",
     "SimpleRetryMiddleware",

--- a/taskiq/abc/scheduler_plugin.py
+++ b/taskiq/abc/scheduler_plugin.py
@@ -1,0 +1,107 @@
+from collections.abc import Coroutine
+from types import CoroutineType
+from typing import TYPE_CHECKING, Any, Union
+
+if TYPE_CHECKING:  # pragma: no cover
+    from taskiq.abc.schedule_source import ScheduleSource
+    from taskiq.scheduler.scheduled_task import ScheduledTask
+    from taskiq.scheduler.scheduler import TaskiqScheduler
+
+
+class SchedulerPlugin:  # pragma: no cover
+    """
+    Base class for scheduler plugins.
+
+    Scheduler plugins observe the scheduler's lifecycle.
+    They receive notifications when schedules are refreshed
+    from a source and when a scheduled task is sent.
+
+    Plugins are observers: unlike schedule sources they cannot
+    cancel or modify tasks. Exceptions raised from event hooks
+    (`on_schedules_updated`, `pre_send`, `post_send`) are logged
+    and suppressed, so a failing plugin never breaks scheduling.
+    Exceptions from `startup` are propagated to fail fast on boot.
+
+    All hooks can be either sync or async.
+    """
+
+    def __init__(self) -> None:
+        self.scheduler: TaskiqScheduler = None  # type: ignore
+
+    def set_scheduler(self, scheduler: "TaskiqScheduler") -> None:
+        """
+        Sets scheduler to plugin.
+
+        This gives the plugin access to the broker
+        and all schedule sources of the scheduler.
+
+        :param scheduler: scheduler to set.
+        """
+        self.scheduler = scheduler
+
+    def startup(
+        self,
+    ) -> Union[None, Coroutine[Any, Any, None], "CoroutineType[Any, Any, None]"]:
+        """
+        Startup method to perform various action during startup.
+
+        This function can be either sync or async.
+        Executed during scheduler's startup, after the broker's startup.
+
+        :returns nothing.
+        """
+
+    def shutdown(
+        self,
+    ) -> Union[None, Coroutine[Any, Any, None], "CoroutineType[Any, Any, None]"]:
+        """
+        Shutdown method to perform various action during shutdown.
+
+        This function can be either sync or async.
+        Executed during scheduler's shutdown, before the broker's shutdown.
+
+        :returns nothing.
+        """
+
+    def on_schedules_updated(
+        self,
+        source: "ScheduleSource",
+        schedules: "list[ScheduledTask]",
+    ) -> Union[None, Coroutine[Any, Any, None], "CoroutineType[Any, Any, None]"]:
+        """
+        This hook is called when schedules are refreshed from a source.
+
+        The scheduler refreshes all its sources on startup and
+        then periodically, based on its update interval. This hook
+        receives the full list of schedules a source returned.
+
+        :param source: source the schedules were fetched from.
+        :param schedules: all schedules the source returned.
+        """
+
+    def pre_send(
+        self,
+        source: "ScheduleSource",
+        task: "ScheduledTask",
+    ) -> Union[None, Coroutine[Any, Any, None], "CoroutineType[Any, Any, None]"]:
+        """
+        This hook is called right before a scheduled task is sent.
+
+        It is not called if the source's own `pre_send`
+        cancelled the task.
+
+        :param source: source that triggered this task.
+        :param task: task that is about to be sent.
+        """
+
+    def post_send(
+        self,
+        source: "ScheduleSource",
+        task: "ScheduledTask",
+    ) -> Union[None, Coroutine[Any, Any, None], "CoroutineType[Any, Any, None]"]:
+        """
+        This hook is called right after a scheduled task is sent.
+
+        :param source: source that triggered this task.
+        :param task: task that has been sent.
+        """

--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -74,7 +74,10 @@ async def get_all_schedules(
     schedules: list[list[ScheduledTask]] = await asyncio.gather(
         *[get_schedules(source) for source in scheduler.sources],
     )
-    return list(zip(scheduler.sources, schedules, strict=True))
+    result = list(zip(scheduler.sources, schedules, strict=True))
+    for source, task_list in result:
+        await scheduler.on_schedules_updated(source, task_list)
+    return result
 
 
 class CronValueError(Exception):

--- a/taskiq/scheduler/scheduler.py
+++ b/taskiq/scheduler/scheduler.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from taskiq.exceptions import ScheduledTaskCancelledError
 from taskiq.kicker import AsyncKicker
@@ -9,6 +9,7 @@ from taskiq.utils import maybe_awaitable
 if TYPE_CHECKING:  # pragma: no cover
     from taskiq.abc.broker import AsyncBroker
     from taskiq.abc.schedule_source import ScheduleSource
+    from taskiq.abc.scheduler_plugin import SchedulerPlugin
 
 logger = getLogger(__name__)
 
@@ -20,9 +21,13 @@ class TaskiqScheduler:
         self,
         broker: "AsyncBroker",
         sources: list["ScheduleSource"],
+        plugins: "list[SchedulerPlugin] | None" = None,
     ) -> None:  # pragma: no cover
         self.broker = broker
         self.sources = sources
+        self.plugins = plugins or []
+        for plugin in self.plugins:
+            plugin.set_scheduler(self)
 
     async def startup(self) -> None:  # pragma: no cover
         """
@@ -32,6 +37,45 @@ class TaskiqScheduler:
         connections or anything you'd like.
         """
         await self.broker.startup()
+        for plugin in self.plugins:
+            await maybe_awaitable(plugin.startup())
+
+    async def _emit(self, hook: str, *args: Any) -> None:
+        """
+        Call a hook on every plugin, suppressing errors.
+
+        Plugins are observers, so a failing plugin
+        must never break scheduling. Exceptions are
+        logged and suppressed.
+
+        :param hook: name of the hook to call.
+        :param args: arguments to pass to the hook.
+        """
+        for plugin in self.plugins:
+            try:
+                await maybe_awaitable(getattr(plugin, hook)(*args))
+            except Exception:
+                logger.exception(
+                    "Scheduler plugin %s failed in %s hook.",
+                    type(plugin).__name__,
+                    hook,
+                )
+
+    async def on_schedules_updated(
+        self,
+        source: "ScheduleSource",
+        schedules: list[ScheduledTask],
+    ) -> None:
+        """
+        This method is called when schedules are refreshed from a source.
+
+        It notifies all plugins with the full list of
+        schedules the source returned.
+
+        :param source: source the schedules were fetched from.
+        :param schedules: all schedules the source returned.
+        """
+        await self._emit("on_schedules_updated", source, schedules)
 
     async def on_ready(self, source: "ScheduleSource", task: ScheduledTask) -> None:
         """
@@ -47,6 +91,7 @@ class TaskiqScheduler:
         except ScheduledTaskCancelledError:
             logger.info("Scheduled task %s has been cancelled.", task.task_name)
         else:
+            await self._emit("pre_send", source, task)
             await (
                 AsyncKicker(task.task_name, self.broker, task.labels)
                 .with_labels(
@@ -59,7 +104,16 @@ class TaskiqScheduler:
                 )
             )
             await maybe_awaitable(source.post_send(task))
+            await self._emit("post_send", source, task)
 
     async def shutdown(self) -> None:
         """Shutdown the scheduler process."""
+        for plugin in self.plugins:
+            try:
+                await maybe_awaitable(plugin.shutdown())
+            except Exception:
+                logger.exception(
+                    "Scheduler plugin %s failed to shut down.",
+                    type(plugin).__name__,
+                )
         await self.broker.shutdown()

--- a/taskiq/scheduler_plugins/__init__.py
+++ b/taskiq/scheduler_plugins/__init__.py
@@ -1,0 +1,7 @@
+"""Package for scheduler plugins."""
+
+from taskiq.scheduler_plugins.taskiq_admin_plugin import TaskiqAdminSchedulerPlugin
+
+__all__ = [
+    "TaskiqAdminSchedulerPlugin",
+]

--- a/taskiq/scheduler_plugins/taskiq_admin_plugin.py
+++ b/taskiq/scheduler_plugins/taskiq_admin_plugin.py
@@ -1,0 +1,329 @@
+import asyncio
+import contextlib
+import json
+from datetime import datetime, timezone
+from logging import getLogger
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
+
+import aiohttp
+
+from taskiq.abc.schedule_source import ScheduleSource
+from taskiq.abc.scheduler_plugin import SchedulerPlugin
+from taskiq.compat import model_dump, model_validate
+from taskiq.kicker import AsyncKicker
+from taskiq.scheduler.scheduled_task import ScheduledTask
+
+if TYPE_CHECKING:  # pragma: no cover
+    from taskiq.abc.broker import AsyncTaskiqDecoratedTask
+
+__all__ = ("TaskiqAdminSchedulerPlugin",)
+
+_logger = getLogger("taskiq.taskiq_admin_scheduler_plugin")
+
+
+def _json_safe(value: Any) -> Any:
+    """Return the value if it's JSON serializable, its repr otherwise."""
+    try:
+        json.dumps(value)
+    except Exception:
+        return repr(value)
+    return value
+
+
+def _is_editable_source(source: ScheduleSource) -> bool:
+    """
+    Check whether a source supports adding and deleting schedules.
+
+    Sources that don't override the optional `add_schedule` and
+    `delete_schedule` methods of the `ScheduleSource` base class
+    (like the label based one) are read-only for the admin.
+    """
+    source_class = type(source)
+    return (
+        source_class.add_schedule is not ScheduleSource.add_schedule
+        and source_class.delete_schedule is not ScheduleSource.delete_schedule
+    )
+
+
+def _dump_schedule(schedule: ScheduledTask) -> dict[str, Any]:
+    """
+    Serialize a schedule into a snapshot item.
+
+    If the schedule's arguments cannot be serialized to JSON,
+    they are replaced with their reprs and the item is marked
+    as opaque, so the admin disables editing and triggering for it.
+    """
+    try:
+        data = model_dump(schedule)
+        opaque = False
+    except Exception:
+        opaque = True
+        data = {
+            "cron": schedule.cron,
+            "args": [repr(arg) for arg in schedule.args],
+            "kwargs": {key: repr(value) for key, value in schedule.kwargs.items()},
+            "labels": {key: repr(value) for key, value in schedule.labels.items()},
+            "cron_offset": (
+                None if schedule.cron_offset is None else str(schedule.cron_offset)
+            ),
+            "time": None if schedule.time is None else schedule.time.isoformat(),
+            "interval": None if schedule.interval is None else str(schedule.interval),
+        }
+    cron_offset = data.get("cron_offset")
+    return {
+        "scheduleId": schedule.schedule_id,
+        "taskName": schedule.task_name,
+        "cron": data.get("cron"),
+        "cronOffset": None if cron_offset is None else str(cron_offset),
+        "time": data.get("time"),
+        "interval": data.get("interval"),
+        "args": data.get("args") or [],
+        "kwargs": data.get("kwargs") or {},
+        "labels": data.get("labels") or {},
+        "opaque": opaque,
+    }
+
+
+class TaskiqAdminSchedulerPlugin(SchedulerPlugin):
+    """
+    A scheduler plugin that syncs schedules with the taskiq-admin panel.
+
+    The counterpart of `TaskiqAdminMiddleware` for the scheduler process.
+    On every schedule refresh it pushes a snapshot of each source to the
+    admin, on startup it reports all registered tasks, and in the
+    background it polls the admin for commands created from its UI
+    (delete, add, trigger) and applies them to the sources or the broker.
+
+    All HTTP errors are logged and suppressed, so an unavailable
+    admin never breaks scheduling.
+
+    Attributes:
+        url (str): Base URL of the admin API.
+        api_token (str): Token used for authenticating with the API.
+        timeout (int): Timeout (in seconds) for API requests.
+        poll_interval (float): Delay between command polls, in seconds.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        api_token: str,
+        timeout: int = 5,
+        poll_interval: float = 2.0,
+        source_names: dict[ScheduleSource, str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.url = url
+        self.api_token = api_token
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self._explicit_names = source_names or {}
+        self._names: dict[int, str] = {}
+        self._client: aiohttp.ClientSession | None = None
+        self._poll_task: asyncio.Task[Any] | None = None
+
+    def _get_client(self) -> aiohttp.ClientSession:
+        """Create and cache session."""
+        if self._client is None or self._client.closed:
+            self._client = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=self.timeout),
+            )
+        return self._client
+
+    async def _post(self, endpoint: str, payload: dict[str, Any]) -> Any:
+        """
+        Send a POST request to the admin.
+
+        Returns the parsed response, or None if the request failed.
+        """
+        try:
+            client = self._get_client()
+            async with client.post(
+                urljoin(self.url, endpoint),
+                headers={"access-token": self.api_token},
+                json=payload,
+            ) as response:
+                response.raise_for_status()
+                return await response.json()
+        except Exception as exc:
+            _logger.warning("Cannot reach taskiq-admin at %s: %s", self.url, exc)
+            return None
+
+    def _resolve_names(self) -> None:
+        """Assign a unique name to every source of the scheduler."""
+        used: set[str] = set()
+        for source in self.scheduler.sources:
+            name = self._explicit_names.get(source, type(source).__name__)
+            deduplicated = name
+            counter = 1
+            while deduplicated in used:
+                counter += 1
+                deduplicated = f"{name}-{counter}"
+            used.add(deduplicated)
+            self._names[id(source)] = deduplicated
+
+    def source_name(self, source: ScheduleSource) -> str:
+        """
+        Get the admin-facing name of a source.
+
+        :param source: source to get the name of.
+        :return: name of the source.
+        """
+        return self._names[id(source)]
+
+    async def startup(self) -> None:
+        """Report the broker's tasks and start the command polling loop."""
+        self._resolve_names()
+        await self._push_registered_tasks()
+        self._poll_task = asyncio.get_event_loop().create_task(self._poll_loop())
+
+    async def shutdown(self) -> None:
+        """Stop the polling loop and close the session."""
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poll_task
+        if self._client is not None:
+            await self._client.close()
+
+    async def on_schedules_updated(
+        self,
+        source: ScheduleSource,
+        schedules: list[ScheduledTask],
+    ) -> None:
+        """
+        Push a snapshot of the refreshed source to the admin.
+
+        :param source: source the schedules were fetched from.
+        :param schedules: all schedules the source returned.
+        """
+        await self._push_snapshot(source, schedules)
+
+    async def _push_snapshot(
+        self,
+        source: ScheduleSource,
+        schedules: list[ScheduledTask],
+    ) -> None:
+        """Push the full list of schedules of a source to the admin."""
+        await self._post(
+            "/api/schedules/snapshot",
+            {
+                "sourceName": self.source_name(source),
+                "editable": _is_editable_source(source),
+                "scannedAt": datetime.now(timezone.utc)
+                .replace(tzinfo=None)
+                .isoformat(),
+                "schedules": [_dump_schedule(schedule) for schedule in schedules],
+            },
+        )
+
+    async def _push_registered_tasks(self) -> None:
+        """
+        Push all registered tasks of the broker to the admin.
+
+        This lets the admin run or schedule any known task,
+        even one that has no schedule yet.
+        """
+        tasks: dict[str, AsyncTaskiqDecoratedTask[Any, Any]] = (
+            self.scheduler.broker.get_all_tasks()
+        )
+        await self._post(
+            "/api/schedules/tasks-snapshot",
+            {
+                "tasks": [
+                    {
+                        "name": name,
+                        "labels": {
+                            key: _json_safe(value) for key, value in task.labels.items()
+                        },
+                    }
+                    for name, task in tasks.items()
+                ],
+            },
+        )
+
+    async def _poll_loop(self) -> None:
+        """Poll the admin for commands until cancelled."""
+        while True:
+            try:
+                await self._poll_once()
+            except Exception:
+                _logger.exception("Cannot poll taskiq-admin for commands.")
+            await asyncio.sleep(self.poll_interval)
+
+    async def _poll_once(self) -> None:
+        """Poll, apply and acknowledge commands for every source."""
+        for source in self.scheduler.sources:
+            response = await self._post(
+                "/api/schedules/commands/poll",
+                {"sourceName": self.source_name(source)},
+            )
+            commands = (response or {}).get("commands") or []
+            if not commands:
+                continue
+            results = []
+            for command in commands:
+                status, error = await self._apply_command(command, source)
+                results.append(
+                    {"id": command["id"], "status": status, "error": error},
+                )
+            await self._post("/api/schedules/commands/ack", {"results": results})
+            # An immediate snapshot, so the UI reflects
+            # the applied commands right away.
+            try:
+                schedules = await source.get_schedules()
+            except Exception:
+                _logger.exception(
+                    "Cannot get schedules from source %s.",
+                    self.source_name(source),
+                )
+                continue
+            await self._push_snapshot(source, schedules)
+
+    async def _apply_command(
+        self,
+        command: dict[str, Any],
+        source: ScheduleSource,
+    ) -> tuple[str, str | None]:
+        """
+        Apply a single admin command against a source or the broker.
+
+        Delete and add commands are applied to the source, trigger
+        commands are kicked to the broker directly. A trigger command
+        may carry a task_id to re-run an exact task.
+
+        :param command: command received from the admin.
+        :param source: source the command is scoped to.
+        :return: tuple of resulting status and an optional error.
+        """
+        command_type = command.get("type")
+        payload = command.get("payload") or {}
+        editable = _is_editable_source(source)
+        try:
+            if command_type == "delete":
+                if not editable:
+                    return "failed", "Source does not support deleting schedules."
+                await source.delete_schedule(payload["schedule_id"])
+            elif command_type == "add":
+                if not editable:
+                    return "failed", "Source does not support adding schedules."
+                await source.add_schedule(model_validate(ScheduledTask, payload))
+            elif command_type == "trigger":
+                kicker: AsyncKicker[Any, Any] = AsyncKicker(
+                    payload["task_name"],
+                    self.scheduler.broker,
+                    payload.get("labels") or {},
+                )
+                if payload.get("task_id"):
+                    kicker = kicker.with_task_id(payload["task_id"])
+                await kicker.kiq(
+                    *(payload.get("args") or []),
+                    **(payload.get("kwargs") or {}),
+                )
+            else:
+                return "failed", f"Unknown command type: {command_type}."
+        except Exception as exc:
+            _logger.exception("Cannot apply admin command %s.", command.get("id"))
+            return "failed", repr(exc)
+        return "applied", None

--- a/taskiq/scheduler_plugins/taskiq_admin_plugin.py
+++ b/taskiq/scheduler_plugins/taskiq_admin_plugin.py
@@ -200,6 +200,33 @@ class TaskiqAdminSchedulerPlugin(SchedulerPlugin):
         """
         await self._push_snapshot(source, schedules)
 
+    async def post_send(
+        self,
+        source: ScheduleSource,
+        task: ScheduledTask,
+    ) -> None:
+        """
+        Push a fresh snapshot after a one-off schedule fires.
+
+        One-off (time) schedules delete themselves from their source
+        after firing, so an immediate snapshot keeps the admin from
+        showing them as overdue until the next refresh.
+
+        :param source: source that triggered this task.
+        :param task: task that has been sent.
+        """
+        if task.time is None:
+            return
+        try:
+            schedules = await source.get_schedules()
+        except Exception:
+            _logger.exception(
+                "Cannot get schedules from source %s.",
+                self.source_name(source),
+            )
+            return
+        await self._push_snapshot(source, schedules)
+
     async def _push_snapshot(
         self,
         source: ScheduleSource,

--- a/tests/scheduler/test_scheduler_plugin.py
+++ b/tests/scheduler/test_scheduler_plugin.py
@@ -1,0 +1,190 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from taskiq.abc.schedule_source import ScheduleSource
+from taskiq.abc.scheduler_plugin import SchedulerPlugin
+from taskiq.api import run_scheduler_task
+from taskiq.brokers.inmemory_broker import InMemoryBroker
+from taskiq.cli.scheduler.run import get_all_schedules
+from taskiq.exceptions import ScheduledTaskCancelledError
+from taskiq.scheduler.scheduled_task import ScheduledTask
+from taskiq.scheduler.scheduler import TaskiqScheduler
+from tests.utils import AsyncQueueBroker
+
+
+class DummyScheduleSource(ScheduleSource):
+    def __init__(self, schedules: list[ScheduledTask] | None = None) -> None:
+        self.schedules = schedules or []
+
+    async def get_schedules(self) -> list["ScheduledTask"]:
+        """Return schedules list."""
+        return self.schedules
+
+
+class CancellingScheduleSource(DummyScheduleSource):
+    def pre_send(self, task: "ScheduledTask") -> None:
+        """Raise cancelled error."""
+        raise ScheduledTaskCancelledError
+
+
+class RecordingPlugin(SchedulerPlugin):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[tuple[str, Any]] = []
+
+    def startup(self) -> None:
+        """Record startup."""
+        self.events.append(("startup", None))
+
+    async def shutdown(self) -> None:
+        """Record shutdown."""
+        self.events.append(("shutdown", None))
+
+    async def on_schedules_updated(
+        self,
+        source: "ScheduleSource",
+        schedules: list["ScheduledTask"],
+    ) -> None:
+        """Record schedules update."""
+        self.events.append(("on_schedules_updated", (source, schedules)))
+
+    def pre_send(self, source: "ScheduleSource", task: "ScheduledTask") -> None:
+        """Record pre_send."""
+        self.events.append(("pre_send", (source, task)))
+
+    async def post_send(self, source: "ScheduleSource", task: "ScheduledTask") -> None:
+        """Record post_send."""
+        self.events.append(("post_send", (source, task)))
+
+
+class FailingPlugin(SchedulerPlugin):
+    def on_schedules_updated(
+        self,
+        source: "ScheduleSource",
+        schedules: list["ScheduledTask"],
+    ) -> None:
+        """Raise an error."""
+        raise ValueError("I'm a broken plugin.")
+
+    def pre_send(self, source: "ScheduleSource", task: "ScheduledTask") -> None:
+        """Raise an error."""
+        raise ValueError("I'm a broken plugin.")
+
+
+def get_schedule() -> ScheduledTask:
+    return ScheduledTask(
+        task_name="ping:pong",
+        labels={},
+        args=[],
+        kwargs={},
+        cron="* * * * *",
+    )
+
+
+def test_plugin_gets_scheduler() -> None:
+    plugin = RecordingPlugin()
+    scheduler = TaskiqScheduler(InMemoryBroker(), sources=[], plugins=[plugin])
+
+    assert plugin.scheduler is scheduler
+
+
+async def test_startup_and_shutdown_hooks() -> None:
+    plugin = RecordingPlugin()
+    scheduler = TaskiqScheduler(InMemoryBroker(), sources=[], plugins=[plugin])
+
+    await scheduler.startup()
+    await scheduler.shutdown()
+
+    assert plugin.events == [("startup", None), ("shutdown", None)]
+
+
+async def test_send_hooks_called() -> None:
+    plugin = RecordingPlugin()
+    broker = InMemoryBroker()
+    source = DummyScheduleSource()
+    scheduler = TaskiqScheduler(broker, sources=[source], plugins=[plugin])
+
+    @broker.task(task_name="ping:pong")
+    def _() -> None: ...
+
+    task = get_schedule()
+    await scheduler.on_ready(source, task)
+
+    assert plugin.events == [
+        ("pre_send", (source, task)),
+        ("post_send", (source, task)),
+    ]
+
+
+async def test_send_hooks_skipped_on_cancel() -> None:
+    plugin = RecordingPlugin()
+    source = CancellingScheduleSource()
+    scheduler = TaskiqScheduler(InMemoryBroker(), sources=[source], plugins=[plugin])
+
+    await scheduler.on_ready(source, get_schedule())
+
+    assert plugin.events == []
+
+
+async def test_failing_plugin_does_not_break_scheduling() -> None:
+    plugin = RecordingPlugin()
+    broker = InMemoryBroker()
+    source = DummyScheduleSource()
+    scheduler = TaskiqScheduler(
+        broker,
+        sources=[source],
+        plugins=[FailingPlugin(), plugin],
+    )
+
+    @broker.task(task_name="ping:pong")
+    def _() -> None: ...
+
+    task = get_schedule()
+    await scheduler.on_ready(source, task)
+
+    assert plugin.events == [
+        ("pre_send", (source, task)),
+        ("post_send", (source, task)),
+    ]
+
+
+async def test_schedules_updated_hook() -> None:
+    plugin = RecordingPlugin()
+    schedule = get_schedule()
+    source = DummyScheduleSource([schedule])
+    scheduler = TaskiqScheduler(InMemoryBroker(), sources=[source], plugins=[plugin])
+
+    await get_all_schedules(scheduler)
+
+    assert plugin.events == [("on_schedules_updated", (source, [schedule]))]
+
+
+async def test_plugin_in_scheduler_loop() -> None:
+    plugin = RecordingPlugin()
+    broker = AsyncQueueBroker()
+    schedule = ScheduledTask(
+        task_name="ping:pong",
+        labels={},
+        args=[],
+        kwargs={},
+        time=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    scheduler = TaskiqScheduler(
+        broker,
+        sources=[DummyScheduleSource([schedule])],
+        plugins=[plugin],
+    )
+
+    @broker.task(task_name="ping:pong")
+    def _() -> None: ...
+
+    scheduler_task = asyncio.create_task(run_scheduler_task(scheduler))
+    msg = await asyncio.wait_for(broker.queue.get(), 2)
+    assert msg
+    scheduler_task.cancel()
+
+    hooks = [event[0] for event in plugin.events]
+    assert "on_schedules_updated" in hooks
+    assert "pre_send" in hooks
+    assert "post_send" in hooks

--- a/tests/scheduler_plugins/test_taskiq_admin_plugin.py
+++ b/tests/scheduler_plugins/test_taskiq_admin_plugin.py
@@ -1,0 +1,278 @@
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from taskiq import TaskiqScheduler
+from taskiq.abc.schedule_source import ScheduleSource
+from taskiq.scheduler.scheduled_task import ScheduledTask
+from taskiq.scheduler_plugins import TaskiqAdminSchedulerPlugin
+from tests.utils import AsyncQueueBroker
+
+AdminState = dict[str, list[Any]]
+
+
+class EditableScheduleSource(ScheduleSource):
+    def __init__(self, schedules: list[ScheduledTask] | None = None) -> None:
+        self.schedules = {
+            schedule.schedule_id: schedule for schedule in schedules or []
+        }
+
+    async def get_schedules(self) -> list["ScheduledTask"]:
+        """Return schedules list."""
+        return list(self.schedules.values())
+
+    async def add_schedule(self, schedule: "ScheduledTask") -> None:
+        """Add a new schedule."""
+        self.schedules[schedule.schedule_id] = schedule
+
+    async def delete_schedule(self, schedule_id: str) -> None:
+        """Delete a schedule by id."""
+        self.schedules.pop(schedule_id, None)
+
+
+class ReadOnlyScheduleSource(ScheduleSource):
+    async def get_schedules(self) -> list["ScheduledTask"]:
+        """Return schedules list."""
+        return []
+
+
+@pytest.fixture
+async def admin_server() -> AsyncGenerator[tuple[TestServer, AdminState], None]:
+    state: AdminState = {
+        "snapshots": [],
+        "tasks_snapshots": [],
+        "acks": [],
+        "commands": [],
+    }
+
+    async def handle_snapshot(request: web.Request) -> web.Response:
+        state["snapshots"].append(await request.json())
+        return web.json_response({"success": True})
+
+    async def handle_tasks_snapshot(request: web.Request) -> web.Response:
+        state["tasks_snapshots"].append(await request.json())
+        return web.json_response({"success": True})
+
+    async def handle_poll(request: web.Request) -> web.Response:
+        await request.json()
+        commands, state["commands"] = state["commands"], []
+        return web.json_response({"commands": commands})
+
+    async def handle_ack(request: web.Request) -> web.Response:
+        state["acks"].append(await request.json())
+        return web.json_response({"success": True})
+
+    app = web.Application()
+    app.router.add_post("/api/schedules/snapshot", handle_snapshot)
+    app.router.add_post("/api/schedules/tasks-snapshot", handle_tasks_snapshot)
+    app.router.add_post("/api/schedules/commands/poll", handle_poll)
+    app.router.add_post("/api/schedules/commands/ack", handle_ack)
+
+    server = TestServer(app)
+    await server.start_server()
+    yield server, state
+    await server.close()
+
+
+def make_scheduler(
+    server: TestServer,
+    broker: AsyncQueueBroker,
+    sources: list[ScheduleSource],
+) -> tuple[TaskiqAdminSchedulerPlugin, TaskiqScheduler]:
+    plugin = TaskiqAdminSchedulerPlugin(
+        str(server.make_url("/")),
+        "supersecret",
+        poll_interval=0.05,
+    )
+    scheduler = TaskiqScheduler(broker, sources=sources, plugins=[plugin])
+    return plugin, scheduler
+
+
+def get_schedule() -> ScheduledTask:
+    return ScheduledTask(
+        task_name="ping:pong",
+        labels={},
+        args=[],
+        kwargs={},
+        cron="* * * * *",
+    )
+
+
+async def test_startup_reports_registered_tasks(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    broker = AsyncQueueBroker()
+
+    @broker.task(task_name="ping:pong")
+    def _() -> None: ...
+
+    _, scheduler = make_scheduler(server, broker, [EditableScheduleSource()])
+    await scheduler.startup()
+    await scheduler.shutdown()
+
+    assert state["tasks_snapshots"]
+    names = [task["name"] for task in state["tasks_snapshots"][0]["tasks"]]
+    assert "ping:pong" in names
+
+
+async def test_snapshot_pushed_on_schedules_updated(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    schedule = get_schedule()
+    source = EditableScheduleSource([schedule])
+    plugin, scheduler = make_scheduler(server, AsyncQueueBroker(), [source])
+    plugin._resolve_names()
+
+    await scheduler.on_schedules_updated(source, [schedule])
+
+    assert len(state["snapshots"]) == 1
+    snapshot = state["snapshots"][0]
+    assert snapshot["sourceName"] == "EditableScheduleSource"
+    assert snapshot["editable"] is True
+    item = snapshot["schedules"][0]
+    assert item["scheduleId"] == schedule.schedule_id
+    assert item["taskName"] == "ping:pong"
+    assert item["cron"] == "* * * * *"
+    assert item["opaque"] is False
+
+
+async def test_opaque_fallback_for_unserializable_args(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    schedule = get_schedule()
+    schedule.args = [object()]
+    source = EditableScheduleSource([schedule])
+    plugin, scheduler = make_scheduler(server, AsyncQueueBroker(), [source])
+    plugin._resolve_names()
+
+    await scheduler.on_schedules_updated(source, [schedule])
+
+    item = state["snapshots"][0]["schedules"][0]
+    assert item["opaque"] is True
+    assert "object object" in item["args"][0]
+
+
+async def test_delete_command_applied(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    schedule = get_schedule()
+    source = EditableScheduleSource([schedule])
+    plugin, _ = make_scheduler(server, AsyncQueueBroker(), [source])
+    plugin._resolve_names()
+    state["commands"] = [
+        {
+            "id": "cmd-1",
+            "type": "delete",
+            "payload": {"schedule_id": schedule.schedule_id},
+        },
+    ]
+
+    await plugin._poll_once()
+
+    assert schedule.schedule_id not in source.schedules
+    assert state["acks"][0]["results"] == [
+        {"id": "cmd-1", "status": "applied", "error": None},
+    ]
+    # The plugin pushes a fresh snapshot right after applying commands.
+    assert state["snapshots"][-1]["schedules"] == []
+
+
+async def test_add_command_applied(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    source = EditableScheduleSource()
+    plugin, _ = make_scheduler(server, AsyncQueueBroker(), [source])
+    plugin._resolve_names()
+    state["commands"] = [
+        {
+            "id": "cmd-2",
+            "type": "add",
+            "payload": {
+                "schedule_id": "new-schedule",
+                "task_name": "ping:pong",
+                "labels": {},
+                "args": [],
+                "kwargs": {},
+                "cron": "0 3 * * *",
+            },
+        },
+    ]
+
+    await plugin._poll_once()
+
+    assert "new-schedule" in source.schedules
+    assert source.schedules["new-schedule"].cron == "0 3 * * *"
+    assert state["acks"][0]["results"][0]["status"] == "applied"
+
+
+async def test_trigger_command_kicks_with_task_id(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    broker = AsyncQueueBroker()
+    plugin, _ = make_scheduler(server, broker, [EditableScheduleSource()])
+    plugin._resolve_names()
+    state["commands"] = [
+        {
+            "id": "cmd-3",
+            "type": "trigger",
+            "payload": {
+                "task_name": "ping:pong",
+                "labels": {},
+                "args": [1],
+                "kwargs": {"key": "value"},
+                "task_id": "custom-task-id",
+            },
+        },
+    ]
+
+    await plugin._poll_once()
+
+    message = json.loads(await asyncio.wait_for(broker.queue.get(), 2))
+    assert message["task_id"] == "custom-task-id"
+    assert message["task_name"] == "ping:pong"
+    assert message["args"] == [1]
+    assert message["kwargs"] == {"key": "value"}
+    assert state["acks"][0]["results"][0]["status"] == "applied"
+
+
+async def test_delete_command_fails_on_read_only_source(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    plugin, _ = make_scheduler(server, AsyncQueueBroker(), [ReadOnlyScheduleSource()])
+    plugin._resolve_names()
+    state["commands"] = [
+        {"id": "cmd-4", "type": "delete", "payload": {"schedule_id": "whatever"}},
+    ]
+
+    await plugin._poll_once()
+
+    result = state["acks"][0]["results"][0]
+    assert result["status"] == "failed"
+    assert "does not support" in result["error"]
+
+
+async def test_unavailable_admin_is_suppressed() -> None:
+    source = EditableScheduleSource([get_schedule()])
+    plugin = TaskiqAdminSchedulerPlugin(
+        "http://127.0.0.1:1",
+        "supersecret",
+        timeout=1,
+    )
+    scheduler = TaskiqScheduler(AsyncQueueBroker(), [source], plugins=[plugin])
+    plugin._resolve_names()
+
+    await scheduler.on_schedules_updated(source, await source.get_schedules())
+    await plugin._poll_once()
+    await plugin.shutdown()

--- a/tests/scheduler_plugins/test_taskiq_admin_plugin.py
+++ b/tests/scheduler_plugins/test_taskiq_admin_plugin.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from collections.abc import AsyncGenerator
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -33,6 +34,11 @@ class EditableScheduleSource(ScheduleSource):
     async def delete_schedule(self, schedule_id: str) -> None:
         """Delete a schedule by id."""
         self.schedules.pop(schedule_id, None)
+
+    async def post_send(self, task: "ScheduledTask") -> None:
+        """Delete one-off schedules after they fire."""
+        if task.time is not None:
+            self.schedules.pop(task.schedule_id, None)
 
 
 class ReadOnlyScheduleSource(ScheduleSource):
@@ -244,6 +250,31 @@ async def test_trigger_command_kicks_with_task_id(
     assert message["args"] == [1]
     assert message["kwargs"] == {"key": "value"}
     assert state["acks"][0]["results"][0]["status"] == "applied"
+
+
+async def test_snapshot_pushed_after_oneoff_fires(
+    admin_server: tuple[TestServer, AdminState],
+) -> None:
+    server, state = admin_server
+    broker = AsyncQueueBroker()
+    schedule = ScheduledTask(
+        task_name="ping:pong",
+        labels={},
+        args=[],
+        kwargs={},
+        time=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    source = EditableScheduleSource([schedule])
+    plugin, scheduler = make_scheduler(server, broker, [source])
+    plugin._resolve_names()
+
+    await scheduler.on_ready(source, schedule)
+
+    # The one-off deleted itself on send, and the plugin's post_send
+    # hook pushed a snapshot that no longer contains it.
+    assert schedule.schedule_id not in source.schedules
+    assert state["snapshots"]
+    assert state["snapshots"][-1]["schedules"] == []
 
 
 async def test_delete_command_fails_on_read_only_source(


### PR DESCRIPTION
## Why

Right now there is no way to observe the scheduler from the outside. Broker
middlewares cover sending and executing, but nothing fires when the scheduler
refreshes its sources or dispatches a scheduled task. I hit this while adding
schedule management to taskiq-admin: the admin needs to know which schedules
exist, and there was no hook to get that information from, short of wrapping
every source or forking the loop.

## Scheduler plugins

This adds a `SchedulerPlugin` base class, deliberately modeled after
`TaskiqMiddleware`:

```python
from taskiq import SchedulerPlugin, TaskiqScheduler

class MyPlugin(SchedulerPlugin):
    def on_schedules_updated(self, source, schedules) -> None: ...
    async def post_send(self, source, task) -> None: ...

scheduler = TaskiqScheduler(broker, sources=[...], plugins=[MyPlugin()])
```

Five hooks, all optional, each can be sync or async (`maybe_awaitable`, same
as middlewares):

- `startup` / `shutdown` - around the scheduler's own startup/shutdown
- `on_schedules_updated(source, schedules)` - every time schedules are read
  from a source (on startup and on every `update_interval` refresh)
- `pre_send(source, task)` / `post_send(source, task)` - around dispatching
  a scheduled task; skipped when the source's own `pre_send` cancels it

A couple of decisions I want to flag for review:

- Plugins are observers. They can't cancel or modify tasks. Exceptions from
  the event hooks are logged and swallowed, so a broken plugin can't stop
  scheduling. `startup` exceptions do propagate, failing fast at boot.
- Plugins get `self.scheduler` via `set_scheduler` (the middleware
  `set_broker` pattern), which gives access to the broker and the sources.
- With no plugins passed, nothing changes at all.

The `on_schedules_updated` emission lives in `get_all_schedules` in the CLI
runner, so `taskiq.api.run_scheduler_task` gets it too.

## Built-in plugin: TaskiqAdminSchedulerPlugin

`TaskiqAdminMiddleware` already lives in core, so I put its scheduler
counterpart next to it, under `taskiq/scheduler_plugins/`. Same aiohttp
client, same `access-token` header, same swallow-and-log posture when the
admin is unreachable. No new dependencies.

```python
from taskiq.scheduler_plugins import TaskiqAdminSchedulerPlugin

scheduler = TaskiqScheduler(
    broker,
    sources=[redis_source, LabelScheduleSource(broker)],
    plugins=[
        TaskiqAdminSchedulerPlugin(
            url="http://localhost:3000",
            api_token="supersecret",
            source_names={redis_source: "redis"},
        ),
    ],
)
```

What it does:

- pushes a snapshot of every source's schedules to the admin on each refresh,
  and once more right after a one-off fires (they self-delete on send, and
  without that extra push they'd look overdue in the admin for up to a
  minute)
- reports the broker's registered tasks on startup, so the admin can run or
  schedule any known task, not only the ones that already have schedules
- polls the admin for commands created in its UI (delete / add / trigger,
  where trigger may carry an explicit `task_id` to re-run an exact task) and
  applies them against the source or the broker, acking each result

Sources that don't implement `add_schedule`/`delete_schedule` (e.g.
`LabelScheduleSource`, whose schedules live in code) are reported as
read-only. Arguments that don't survive JSON serialization are sent as reprs
and flagged, so the admin knows not to offer editing for them.

Here's the admin's Scheduled tab fed by this plugin - a redis-like editable
source next to a read-only label source:

![Scheduled tab in taskiq-admin, data coming from the plugin](https://github.com/user-attachments/assets/08053c10-c733-4392-9a71-5232b72b8dd0)

Companion PR on the admin side: https://github.com/taskiq-python/taskiq-admin/pull/18

If you'd rather not have the admin plugin in core, it's one self-contained
file and I'm happy to move it elsewhere - but keeping it next to the
middleware felt consistent.

## Tests

- `tests/scheduler/test_scheduler_plugin.py` - hook dispatch, the cancel
  path, a deliberately broken plugin not affecting scheduling, and a full
  scheduler-loop round trip
- `tests/scheduler_plugins/test_taskiq_admin_plugin.py` - runs against a real
  aiohttp test server (same setup as the admin middleware tests): snapshot
  payloads, the repr fallback, registered-task reporting, applying
  delete/add/trigger commands with acks, custom task ids, read-only
  rejection, and the unreachable-admin case
