### PR TITLE
fix: skip schedules with invalid cron_offset instead of crashing the scheduler

### DIFF
--- a/taskiq/cli/scheduler/run.py
+++ b/taskiq/cli/scheduler/run.py
@@ -99,7 +99,10 @@ def is_cron_task_now(
     # If timezone was specified as string we convert it timezone
     # offset and then apply.
     elif offset and isinstance(offset, str):
-        now = now.astimezone(ZoneInfo(offset))
+        try:
+            now = now.astimezone(ZoneInfo(offset))
+        except Exception as e:
+            raise CronValueError(e) from e
 
     try:
         return pycron.is_now(cron_value, now)

--- a/tests/cli/scheduler/test_is_cron_task_now.py
+++ b/tests/cli/scheduler/test_is_cron_task_now.py
@@ -75,3 +75,21 @@ def test_is_cron_task_now(
 def test_is_cron_task_now_invalid_cron() -> None:
     with pytest.raises(CronValueError):
         is_cron_task_now("invalid cron", datetime.now())
+
+
+def test_is_cron_task_now_invalid_offset_string() -> None:
+    with pytest.raises(CronValueError):
+        is_cron_task_now(
+            cron_value="* * * * *",
+            now=datetime.now(timezone.utc),
+            offset="UTC+3",
+        )
+
+
+def test_is_cron_task_now_unknown_timezone_name() -> None:
+    with pytest.raises(CronValueError):
+        is_cron_task_now(
+            cron_value="* * * * *",
+            now=datetime.now(timezone.utc),
+            offset="Europa/Madrid",
+        )


### PR DESCRIPTION
Closes: #668

`is_cron_task_now` called `ZoneInfo(offset)` outside the `try/except` that converts errors into `CronValueError`, and the scheduler loop only catches `CronValueError`. One schedule with a non-IANA `cron_offset` string (e.g. the natural spelling `"UTC+3"`) raised `ZoneInfoNotFoundError` out of `SchedulerLoop.run` and killed the whole scheduler process.

With this change a bad offset goes through the same path as an invalid cron expression: `CronValueError` is raised, the loop logs the existing `Cannot parse cron` warning and skips that schedule.

Two regression tests cover invalid offset strings: the natural spelling `"UTC+3"` and a typo'd timezone name (`"Europa/Madrid"`). Both fail on master with `ZoneInfoNotFoundError` and pass with this change.

Complements #625 (which fixes duration-string offsets at model-validation time but leaves the runtime guard unhandled).

Validation: full suite passes (`pytest -q`, 324 tests), `black`, `ruff` and `mypy` clean.